### PR TITLE
Workflows target docker hub by Org/Account.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
-name: Publish Docker
+name: GitHub Actions Runner in Docker - Latest
 on:
   push:
-    branches:    
+    paths-ignore:
+      - README.md
+    branches:
       - master
       - develop
 
@@ -11,6 +13,8 @@ jobs:
     steps:
     - name: Copy Repo Files
       uses: actions/checkout@master
+    - name: Get GitHub organization or user
+      run: echo ::set-env name=ORG::$(dirname ${GITHUB_REPOSITORY})
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
@@ -21,12 +25,14 @@ jobs:
     - name: Login
       run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
     - name: Build
-      run: docker buildx build -f Dockerfile -t myoung34/github-runner:latest --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+      run: docker buildx build -f Dockerfile -t ${ORG}/github-runner:latest --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
   ubuntu_bionic_deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Copy Repo Files
       uses: actions/checkout@master
+    - name: Get GitHub organization or user
+      run: echo ::set-env name=ORG::$(dirname ${GITHUB_REPOSITORY})
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
@@ -39,12 +45,14 @@ jobs:
     - name: Login
       run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
     - name: Build
-      run: docker buildx build -f Dockerfile.ubuntu-bionic -t myoung34/github-runner:ubuntu-bionic --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+      run: docker buildx build -f Dockerfile.ubuntu-bionic -t ${ORG}/github-runner:ubuntu-bionic --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
   ubuntu_xenial_deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Copy Repo Files
       uses: actions/checkout@master
+    - name: Get GitHub organization or user
+      run: echo ::set-env name=ORG::$(dirname ${GITHUB_REPOSITORY})
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
@@ -57,4 +65,4 @@ jobs:
     - name: Login
       run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
     - name: Build
-      run: docker buildx build -f Dockerfile.ubuntu-xenial -t myoung34/github-runner:ubuntu-xenial --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+      run: docker buildx build -f Dockerfile.ubuntu-xenial -t ${ORG}/github-runner:ubuntu-xenial --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,21 @@
-name: Publish Docker
+name: GitHub Actions Runner in Docker - Release
 on:
   push:
+    paths-ignore:
+      - README.md
     tags:
       - '*'
 
 jobs:
-  ubuntu_tag_deploy:
+  ubuntu_latest_tag:
     runs-on: ubuntu-latest
     steps:
     - name: Copy Repo Files
       uses: actions/checkout@master
     - name: get version
-      run: echo "::set-env name=TAG::$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")"
+      run: echo ::set-env name=TAG::${GITHUB_REF#refs/tags/}
+    - name: Get GitHub organization or user
+      run: echo ::set-env name=ORG::$(dirname ${GITHUB_REPOSITORY})
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
@@ -22,14 +26,16 @@ jobs:
     - name: Login
       run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
     - name: Build
-      run: docker buildx build -f Dockerfile -t myoung34/github-runner:${TAG} --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
-  ubuntu_bionic_deploy:
+      run: docker buildx build -f Dockerfile -t ${ORG}/github-runner:${TAG} --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+  ubuntu_bionic_tag:
     runs-on: ubuntu-latest
     steps:
     - name: Copy Repo Files
       uses: actions/checkout@master
     - name: get version
-      run: echo "::set-env name=TAG::$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")"
+      run: echo ::set-env name=TAG::${GITHUB_REF#refs/tags/}
+    - name: Get GitHub organization or user
+      run: echo ::set-env name=ORG::$(dirname ${GITHUB_REPOSITORY})
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
@@ -42,14 +48,16 @@ jobs:
     - name: Login
       run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
     - name: Build
-      run: docker buildx build -f Dockerfile.ubuntu-bionic -t myoung34/github-runner:${TAG}-ubuntu-bionic --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
-  ubuntu_xenial_deploy:
+      run: docker buildx build -f Dockerfile.ubuntu-bionic -t ${ORG}/github-runner:${TAG}-ubuntu-bionic --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+  ubuntu_xenial_tag:
     runs-on: ubuntu-latest
     steps:
     - name: Copy Repo Files
       uses: actions/checkout@master
     - name: get version
-      run: echo "::set-env name=TAG::$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")"
+      run: echo ::set-env name=TAG::${GITHUB_REF#refs/tags/}
+    - name: Get GitHub organization or user
+      run: echo ::set-env name=ORG::$(dirname ${GITHUB_REPOSITORY})
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
@@ -62,4 +70,4 @@ jobs:
     - name: Login
       run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
     - name: Build
-      run: docker buildx build -f Dockerfile.ubuntu-xenial -t myoung34/github-runner:${TAG}-ubuntu-xenial --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+      run: docker buildx build -f Dockerfile.ubuntu-xenial -t ${ORG}/github-runner:${TAG}-ubuntu-xenial --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ RUN apt-get update && \
     liblttng-ust0 \
     libcurl4-openssl-dev \
     inetutils-ping \
-    maven \
-  # https://bugs.launchpad.net/ubuntu/+source/nodejs/+bug/1794589
-  && [[ $(lsb_release -cs) == "bionic" ]] && ( apt-get install -y nodejs && curl -L https://www.npmjs.com/install.sh | sh ) || ( apt-get install -y npm ) \
   && rm -rf /var/lib/apt/lists/* \
   && c_rehash \
   && cd /tmp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && \
     liblttng-ust0 \
     libcurl4-openssl-dev \
     inetutils-ping \
+    maven \
+  # https://bugs.launchpad.net/ubuntu/+source/nodejs/+bug/1794589
+  && [[ $(lsb_release -cs) == "bionic" ]] && ( apt-get install -y nodejs && curl -L https://www.npmjs.com/install.sh | sh ) || ( apt-get install -y npm ) \
   && rm -rf /var/lib/apt/lists/* \
   && c_rehash \
   && cd /tmp \
@@ -37,7 +40,7 @@ RUN apt-get update && \
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
   && [[ $(lsb_release -cs) == "eoan" ]] && ( add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu disco stable" ) || ( add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" )\
   && apt-get update \
-  && apt-get install -y docker-ce --no-install-recommends \
+  && apt-get install -y docker-ce docker-ce-cli containerd.io --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /actions-runner

--- a/README.md
+++ b/README.md
@@ -18,20 +18,29 @@ Manual:
 docker run -it \
   -e REPO_URL="https://github.com/myoung34/LEDSpicer" \
   -e RUNNER_TOKEN="footoken" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   myoung34/github-runner:latest
 ```
 
-Or as an alias:
+Or as a shell function (as root):
 
 ```
-function run-server {
-    name=github-actions-$(echo $1 | sed 's/\//-/g')
+function github-runner {
+    name=github-runner-${1//\//-}
+    org=$(dirname $1)
+    repo=$(basename $1)
+    tag=${3:-latest}
     docker rm -f $name
-    docker run -d --restart=always -e REPO_URL="https://github.com/$1" -e RUNNER_TOKEN="$2" -v /var/run/docker.sock:/var/run/docker.sock --name $name github-runner:latest
+    docker run -d --restart=always \
+        -e REPO_URL="https://github.com/${org}/${repo}" \
+        -e RUNNER_TOKEN="$2" \
+        -e RUNNER_NAME="linux-${repo}" \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --name $name ${org}/github-runner:${tag}
 }
 
-run-server your-account/your-repo        AARGHTHISISYOURGHACTIONSTOKEN
-run-server your-account/some-other-repo  ARGHANOTHERGITHUBACTIONSTOKEN
+github-runner your-account/your-repo       AARGHTHISISYOURGHACTIONSTOKEN
+github-runner your-account/some-other-repo ARGHANOTHERGITHUBACTIONSTOKEN ubuntu-xenial
 ```
 
 Nomad:


### PR DESCRIPTION
### Install maven & npm. Workflows target docker hub by Org/Account.

* Make workflows target docker hub by organization/account.
* Modified sample function to support different organization/account when pulling docker image. This assumes the same value in both GitHub and Docker Hub.
* Modified the names of the workflows to reflect their purpose.

WRT the installing npm or maven or any other tools, in reading through the code for the [linux runner virtual environments](https://github.com/actions/virtual-environments/tree/master/images/linux), it seems the next logical step would be to leverage those same shell scripts. The fact that GitHub is using packer adds a wrinkle of complexity. I think that could be overcome with some jq scripting.