### PR TITLE
Get Runner Token Automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
     liblttng-ust0 \
     libcurl4-openssl-dev \
     inetutils-ping \
+    jq \
   && rm -rf /var/lib/apt/lists/* \
   && c_rehash \
   && cd /tmp \
@@ -40,6 +41,9 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
   && apt-get install -y docker-ce docker-ce-cli containerd.io --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
+RUN curl -sL "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+  && chmod +x /usr/local/bin/docker-compose
+
 WORKDIR /actions-runner
 COPY install_actions.sh /actions-runner
 
@@ -47,7 +51,6 @@ RUN chmod +x /actions-runner/install_actions.sh \
   && /actions-runner/install_actions.sh ${GH_RUNNER_VERSION} ${TARGETPLATFORM} \
   && rm /actions-runner/install_actions.sh
 
-WORKDIR /_work
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Docker Github Actions Runner
 ============================
 
-This will run the [new self-hosted github actions runners](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/hosting-your-own-runners) with docker-in-docker
+This will run the [new self-hosted github actions runners](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/hosting-your-own-runners).
 
 This has been tested and verified on:
 
@@ -102,7 +102,6 @@ spec:
         hostPath:
           path: /tmp/github-runner
       containers:
-      containers:
       - name: runner
         image: myoung34/github-runner:latest
         env:
@@ -110,6 +109,10 @@ spec:
           value: footoken
         - name: REPO_URL
           value: https://github.com/your-account/your-repo
+        - name: RUNNER_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: RUNNER_WORKDIR
           value: /tmp/github-runner
         volumeMounts:
@@ -135,4 +138,19 @@ jobs:
     - uses: actions/checkout@v1
     - name: build packages
       run: make all
+```
+
+## Automatically Acquiring a Runner Token  ##
+
+A runner token can be automatically acquired at runtime if `ACCESS_TOKEN` (a GitHub personal access token) is a supplied. This uses the [GitHub Actions API](https://developer.github.com/v3/actions/self_hosted_runners/#create-a-registration-token). e.g.:
+
+```
+docker run -d --restart always --name github-runner \
+  -e ACCESS_TOKEN="footoken" \
+  -e REPO_URL="https://github.com/myoung34/repo" \
+  -e RUNNER_NAME="foo-runner" \
+  -e RUNNER_WORKDIR="/tmp/github-runner" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/github-runner:/tmp/github-runner \
+  myoung34/github-runner:latest
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,29 @@
 #!/bin/bash
+
 export RUNNER_ALLOW_RUNASROOT=1
 export PATH=$PATH:/actions-runner
+
 _RUNNER_NAME=${RUNNER_NAME:-default}
 _RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work}
-config.sh --url "${REPO_URL}" --token "${RUNNER_TOKEN}" --name "${_RUNNER_NAME}" --work "${_RUNNER_WORKDIR}"
-exec run.sh
+
+if [[ -n "${ACCESS_TOKEN}" ]]; then
+    URI=https://api.github.com
+    API_VERSION=v3
+    API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
+    AUTH_HEADER="Authorization: token ${ACCESS_TOKEN}"
+
+    _PROTO="$(echo "${REPO_URL}" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+    _URL="$(echo "${REPO_URL/${_PROTO}/}")"
+    _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
+    _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
+    _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+
+    RUNNER_TOKEN="$(curl -XPOST -fsSL \
+    -H "${AUTH_HEADER}" \
+    -H "${API_HEADER}" \
+    "${URI}/repos/${_ACCOUNT}/${_REPO}/actions/runners/registration-token" \
+    | jq -r '.token')"
+fi
+
+./config.sh --url "${REPO_URL}" --token "${RUNNER_TOKEN}" --name "${_RUNNER_NAME}" --work "${_RUNNER_WORKDIR}"
+./run.sh


### PR DESCRIPTION
- Add the ability to specify a personal access token to use for calling the new Actions API for a runner token
- Add `jq` and `docker-compose` to the `Dockerfile`
- Update `README.md`