### PR TITLE
Only one runner can use the same RUNNER_WORKDIR if it is shared storage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This has been tested and verified on:
  * armhf
  * armv7
  * arm64
+ 
+**NOTE: Only one runner can use the same RUNNER_WORKDIR if it is shared storage.**
 
 ## Examples ##
 
@@ -21,7 +23,7 @@ docker run -d --restart always --name github-runner \
   -e RUNNER_TOKEN="footoken" \
   -e RUNNER_WORKDIR="/tmp/github-runner" \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /tmp/github-runner:/tmp/github-runner \
+  -v /tmp/github-runner-repo:/tmp/github-runner-repo \
   myoung34/github-runner:latest
 ```
 
@@ -40,7 +42,7 @@ function github-runner {
         -e RUNNER_NAME="linux-${repo}" \
         -e RUNNER_WORKDIR="/tmp/github-runner" \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        -v /tmp/github-runner:/tmp/github-runner \
+        -v /tmp/github-runner-${repo}:/tmp/github-runner-${repo} \
         --name $name ${org}/github-runner:${tag}
 }
 
@@ -69,7 +71,7 @@ job "github_runner" {
       image = "myoung34/github-runner:latest"
       volumes = [
         "/var/run/docker.sock:/var/run/docker.sock",
-        "/tmp/github-runner:/tmp/github-runner",
+        "/tmp/github-runner-your-repo:/tmp/github-runner-your-repo",
       ]
     }
   }
@@ -100,7 +102,7 @@ spec:
           path: /var/run/docker.sock
       - name: workdir
         hostPath:
-          path: /tmp/github-runner
+          path: /tmp/github-runner-your-repo
       containers:
       - name: runner
         image: myoung34/github-runner:latest
@@ -114,12 +116,12 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: RUNNER_WORKDIR
-          value: /tmp/github-runner
+          value: /tmp/github-runner-your-repo
         volumeMounts:
         - name: dockersock
           mountPath: /var/run/docker.sock
         - name: workdir
-          mountPath: /tmp/github-runner
+          mountPath: /tmp/github-runner-your-repo
 ```
 
 ## Usage From GH Actions Workflow ##
@@ -151,6 +153,6 @@ docker run -d --restart always --name github-runner \
   -e RUNNER_NAME="foo-runner" \
   -e RUNNER_WORKDIR="/tmp/github-runner" \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /tmp/github-runner:/tmp/github-runner \
+  -v /tmp/github-runner-your-repo:/tmp/github-runner-your-repo \
   myoung34/github-runner:latest
 ```


### PR DESCRIPTION
The "Set up job" step at the beginning of a workflow will delete the `_actions` directory. Therefore, you cannot have more than one container running on the same Docker host sharing storage via a volume mount (e.g. `/tmp/github-runner`) used by `RUNNER_WORKDIR`.

https://github.community/t5/GitHub-Actions/Does-self-hosted-runner-clear-all-previous-actions-during-quot/m-p/50061