### PR TITLE
Remove runner on kill/shutdown

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,4 +47,11 @@ echo "Configuring"
     --unattended \
     --replace
 
+remove() {
+    ./config.sh remove --unattended --token "${RUNNER_TOKEN}"
+}
+
+trap 'remove; exit 130' INT
+trap 'remove; exit 143' TERM
+
 ./run.sh


### PR DESCRIPTION
This is a topic for discussion

I am planning to use it in Kube cluster with auto-scaling.

I think, its better to remove agent from the pool when cluster kills an runner node/pod.  I cant see any negative feedback on this - there is no such thing as Runner history or something like that as in Teamcity eq (as far as i know). This will create only one extra API call.

