### PR TITLE
fix(docs): quote boolean in docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ services:
       RUNNER_NAME: example-name
       RUNNER_TOKEN: someGithubTokenHere
       RUNNER_WORKDIR: /tmp/runner/work
-      ORG_RUNNER: false
+      ORG_RUNNER: 'false'
       LABELS: linux,x64,gpu
     security_opt:
       # needed on SELinux systems to allow docker container to manage other docker containers


### PR DESCRIPTION
Here's the relevant error when using the current snippet:

```
services.worker.environment.ORG_RUNNER contains true, which is an invalid type, it should be a string, number, or a null
```

