### PR TITLE
feat: add unzip to docker image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -11,6 +11,7 @@ RUN apt-get update && \
     awscli \
     curl \
     tar \
+    unzip \
     apt-transport-https \
     ca-certificates \
     sudo \


### PR DESCRIPTION
Some actions (like https://github.com/hashicorp/setup-terraform) needs `unzip` which is a pretty tiny dependency that can be added seamlessly.