### PR TITLE
fix: move to ubuntu 18.04

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ubuntu:eoan
+FROM ubuntu:18.04
 LABEL maintainer="myoung34@my.apsu.edu"
 
 ARG GIT_VERSION="2.26.2"


### PR DESCRIPTION
`19.10` is not supported by https://github.com/actions/setup-python action. Move to a LTS version.
See
- https://github.com/actions/setup-python/issues/96#issuecomment-633941157
- https://raw.githubusercontent.com/actions/python-versions/master/versions-manifest.json
