### PR TITLE
Update the docker-compose version

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,6 +2,7 @@ FROM ubuntu:eoan
 LABEL maintainer="myoung34@my.apsu.edu"
 
 ARG GIT_VERSION="2.26.2"
+ENV DOCKER_COMPOSE_VERSION="1.26.2"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
@@ -37,7 +38,7 @@ RUN apt-get update && \
   && [[ $(lsb_release -cs) == "eoan" ]] && ( add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu disco stable" ) || ( add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" ) \
   && apt-get update \
   && apt-get install -y docker-ce docker-ce-cli containerd.io --no-install-recommends \
-  && curl -sL "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+  && curl -sL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
   && chmod +x /usr/local/bin/docker-compose \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /tmp/*


### PR DESCRIPTION
Updates the docker-compose version from 1.25.4 to 1.26.2
The environment variable makes it easier install a newer version