### PR TITLE
Fix deregistration with dumb-init

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,6 +25,7 @@ RUN apt-get update && \
     libcurl4-openssl-dev \
     inetutils-ping \
     jq \
+    dumb-init \
   && c_rehash \
   && cd /tmp \
   && curl -sL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz -o git.tgz \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/dumb-init /bin/bash
 
 export RUNNER_ALLOW_RUNASROOT=1
 export PATH=$PATH:/actions-runner


### PR DESCRIPTION
This resolves the issue reported in #34 where deregistration fails because docker is not passing SIGTERM to the entrypoint.