### PR TITLE
Add support for the setup-python action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM myoung34/github-runner-base:latest
 LABEL maintainer="myoung34@my.apsu.edu"
 
+ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+RUN mkdir -p /opt/hostedtoolcache
+
 ARG GH_RUNNER_VERSION="2.273.5"
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
The setup-python action [README.md](https://github.com/actions/setup-python/blob/main/README.md#linux) says self hosted runners need /opt/hostedtoolcache to exist and the AGENT_TOOLSDIRECTORY environment variable to point at it.
