### PR TITLE
Removed build from example docker-compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ version: '2.3'
 
 services:
   worker:
-    build: .
     image: myoung34/github-runner:latest
     environment:
       REPO_URL: https://github.com/example/repo


### PR DESCRIPTION
All the build line in the example `docker-compose.yml` does is give an error when trying to run it so it would be better to remove it. (Unless there's something I don't know about)