### PR TITLE
fix: Kubernetes sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ spec:
         image: myoung34/github-runner:latest
         env:
         - name: ORG_RUNNER
-          value: true
+          value: "true"
         - name: ORG_NAME
           value: octokode
         - name: LABELS


### PR DESCRIPTION
Hi there.
Thanks to you, we were able to get the self-hosted runner working in our environment.

When I ran the Kuberenetes deployment sample described in the README, I got the following error.

```bash
$ kubectl apply -f docker-github-actions-runner-deploy.yml
The request is invalid: patch: Invalid value: "map[metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"actions-runner\",\"namespace\":\"github-actions-runner\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"actions-runner\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"actions-runner\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"ORG_RUNNER\",\"value\":true},{\"name\":\"ORG_NAME\",\"value\":\"octokode\"},{\"name\":\"LABELS\",\"value\":\"my-label,other-label\"},{\"name\":\"RUNNER_TOKEN\",\"value\":\"footoken\"},{\"name\":\"REPO_URL\",\"value\":\"https://github.com/your-account/your-repo\"},{\"name\":\"RUNNER_NAME_PREFIX\",\"value\":\"foo\"},{\"name\":\"RUNNER_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}},{\"name\":\"RUNNER_WORKDIR\",\"value\":\"/tmp/github-runner-your-repo\"},{\"name\":\"RUNNER_GROUP\",\"value\":\"my-group\"}],\"image\":\"myoung34/github-runner:latest\",\"name\":\"runner\",\"volumeMounts\":[{\"mountPath\":\"/var/run/docker.sock\",\"name\":\"dockersock\"},{\"mountPath\":\"/tmp/github-runner-your-repo\",\"name\":\"workdir\"}]}],\"volumes\":[{\"hostPath\":{\"path\":\"/var/run/docker.sock\"},\"name\":\"dockersock\"},{\"hostPath\":{\"path\":\"/tmp/github-runner-your-repo\"},\"name\":\"workdir\"}]}}}}\n]] spec:map[template:map[spec:map[]]]]": unrecognized type: string
```

The versions of kubectl and Kubernetes (EKS) that I use are as follows.

```bash
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.1", GitCommit:"206bcadf021e76c27513500ca24182692aabd17e", GitTreeState:"clean", BuildDate:"2020-09-09T19:10:58Z", GoVersion:"go1.15.1", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"18+", GitVersion:"v1.18.8-eks-7c9bda", GitCommit:"7c9bda52c425d0d56d7b93f1377a826b4132c05c", GitTreeState:"clean", BuildDate:"2020-08-28T23:04:33Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
```

The fix is simple, just change "true" to "true".

```
diff --git a/README.md b/README.md
index a1d45ba..dffce04 100644
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ spec:
         image: myoung34/github-runner:latest
         env:
         - name: ORG_RUNNER
-          value: true
+          value: "true"
         - name: ORG_NAME
           value: octokode
         - name: LABELS
```
