### PR TITLE
Update nomad example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ job "github_runner" {
 
     env {
       ACCESS_TOKEN       = "footoken"
-      RUNNER_NAME_PREFIX = "myrunner" \
+      RUNNER_NAME_PREFIX = "myrunner"
       RUNNER_WORKDIR     = "/tmp/github-runner-your-repo"
       RUNNER_GROUP       = "my-group"
       ORG_RUNNER         = "true"
@@ -137,8 +137,11 @@ job "github_runner" {
     }
 
     config {
-      privileged = true
       image = "myoung34/github-runner:latest"
+      
+      privileged  = true
+      userns_mode = "host"
+
       volumes = [
         "/var/run/docker.sock:/var/run/docker.sock",
         "/tmp/github-runner-your-repo:/tmp/github-runner-your-repo",


### PR DESCRIPTION
There's an extra ` \`

I had to add `userns_mode = "host"` to get this to run, otherwise I'd get
```
failed to create container: API error (400): privileged mode is incompatible with user namespaces. You must run the container in the host namespace when running privileged mode
```