### PR TITLE
Add awscliv2

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,8 +8,7 @@ ARG DOCKER_KEY="7EA0A9C3F273FCD8"
 ENV DOCKER_COMPOSE_VERSION="1.27.4"
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
-ENV LC_ALL=en_US.UTF-8
-
+ENV LC_ALL=en_US.UTF-8 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3003,DL4001
@@ -35,6 +34,8 @@ RUN apt-get update && \
     dirmngr \
     openssh-client \
     locales \
+    python3-pip \
+  && pip3 install --no-cache-dir awscliv2 \
   && locale-gen en_US.UTF-8 \
   && dpkg-reconfigure locales \
   && c_rehash \


### PR DESCRIPTION
resolves #87 

* `awscli` v1 is located at `/usr/bin/aws`
* `awscli` v2 is located at `/usr/local/bin/awscliv2`