### PR TITLE
Install zstd

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,6 +25,7 @@ RUN apt-get update && \
     software-properties-common \
     build-essential \
     zlib1g-dev \
+    zstd \
     gettext \
     liblttng-ust0 \
     libcurl4-openssl-dev \


### PR DESCRIPTION
The following is printed in the debug log:
```
##[debug]Checking zstd --version
##[debug]Unable to locate executable file: zstd. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```