### PR TITLE
Add compatibility with enterprise-wide runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `ACCESS_TOKEN` | A [github PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to use to generate `RUNNER_TOKEN` dynamically at container start. Not using this requires a valid `RUNNER_TOKEN` |
 | `ORG_RUNNER` | Only valid if using `ACCESS_TOKEN`. This will set the runner to an org runner. Default is 'false'. Valid values are 'true' or 'false'. If this is set to true you must also set `ORG_NAME` and makes `REPO_URL` unneccesary |
 | `ORG_NAME` | The organization name for the runner to register under. Requires `ORG_RUNNER` to be 'true'. No default value. |
+| `ENTERPRISE_RUNNER` | Only valid if using `ACCESS_TOKEN`. This will set the runner to an enterprise runner. Default is 'false'. Valid values are 'true' or 'false'. If this is set to true you must also set `ENTERPRISE_NAME` and makes `REPO_URL` unneccesary |
+| `ENTERPRISE_NAME` | The enterprise name for the runner to register under. Requires `ENTERPRISE_RUNNER` to be 'true'. No default value. |
 | `LABELS` | A comma separated string to indicate the labels. Default is 'default' |
 | `REPO_URL` | If using a non-organization runner this is the full repository url to register under such as 'https://github.com/myoung34/repo' |
 | `RUNNER_TOKEN` | If not using a PAT for `ACCESS_TOKEN` this will be the runner token provided by the Add Runner UI (a manual process). Note: This token is short lived and will change frequently. `ACCESS_TOKEN` is likely preferred. |
@@ -268,6 +270,7 @@ Creating GitHub personal access token (PAT) for using by self-hosted runner make
 
 * repo (all)
 * admin:org (all) **_(mandatory for organization-wide runner)_**
+* admin:enterprise (all) **_(mandatory for enterprise-wide runner)_**
 * admin:public_key - read:public_key
 * admin:repo_hook - read:repo_hook
 * admin:org_hook
@@ -275,3 +278,19 @@ Creating GitHub personal access token (PAT) for using by self-hosted runner make
 * workflow
 
 Also, when creating a PAT for self-hosted runner which will process events from several repositories of the particular organization, create the PAT using organization owner account. Otherwise your new PAT will not have sufficient privileges for all repositories.
+
+## Run a runner on enterprise scrope  ##
+
+```shell
+docker run -d --restart always --name github-runner \
+  -e ACCESS_TOKEN="footoken" \
+  -e RUNNER_NAME="foo-runner" \
+  -e RUNNER_WORKDIR="/tmp/github-runner-your-repo" \
+  -e RUNNER_GROUP="my-group" \
+  -e ENTERPRISE_RUNNER="true" \
+  -e ENTERPRISE_NAME="my-enterprise" \
+  -e LABELS="my-label,other-label" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/github-runner-your-repo:/tmp/github-runner-your-repo \
+  myoung34/github-runner:latest
+```

--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `RUNNER_NAME` | The name of the runner to use. Supercedes (overrides) `RUNNER_NAME_PREFIX` |
 | `RUNNER_NAME_PREFIX` | A prefix for a randomly generated name (followed by a random 13 digit string). You must not also provide `RUNNER_NAME`. Defaults to `github-runner` |
 | `ACCESS_TOKEN` | A [github PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to use to generate `RUNNER_TOKEN` dynamically at container start. Not using this requires a valid `RUNNER_TOKEN` |
-| `ORG_RUNNER` | Only valid if using `ACCESS_TOKEN`. This will set the runner to an org runner. Default is 'false'. Valid values are 'true' or 'false'. If this is set to true you must also set `ORG_NAME` and makes `REPO_URL` unneccesary |
-| `ORG_NAME` | The organization name for the runner to register under. Requires `ORG_RUNNER` to be 'true'. No default value. |
-| `ENTERPRISE_RUNNER` | Only valid if using `ACCESS_TOKEN`. This will set the runner to an enterprise runner. Default is 'false'. Valid values are 'true' or 'false'. If this is set to true you must also set `ENTERPRISE_NAME` and makes `REPO_URL` unneccesary |
-| `ENTERPRISE_NAME` | The enterprise name for the runner to register under. Requires `ENTERPRISE_RUNNER` to be 'true'. No default value. |
+| `RUNNER_SCOPE` | The scope the runner will be registered on. Valid values are `repo`, `org` and `ent`. For 'org' and 'enterprise', `ACCESS_TOKEN` is required and `REPO_URL` is unneccesary. If 'org', requires `ORG_NAME`; if 'enterprise', requires `ENTERPRISE_NAME`. Default is 'repo'. |
+| `ORG_NAME` | The organization name for the runner to register under. Requires `RUNNER_SCOPE` to be 'org'. No default value. |
+| `ENTERPRISE_NAME` | The enterprise name for the runner to register under. Requires `RUNNER_SCOPE` to be 'enterprise'. No default value. |
 | `LABELS` | A comma separated string to indicate the labels. Default is 'default' |
 | `REPO_URL` | If using a non-organization runner this is the full repository url to register under such as 'https://github.com/myoung34/repo' |
 | `RUNNER_TOKEN` | If not using a PAT for `ACCESS_TOKEN` this will be the runner token provided by the Add Runner UI (a manual process). Note: This token is short lived and will change frequently. `ACCESS_TOKEN` is likely preferred. |
@@ -65,7 +64,7 @@ docker run -d --restart always --name github-runner \
   -e ACCESS_TOKEN="footoken" \
   -e RUNNER_WORKDIR="/tmp/github-runner-your-repo" \
   -e RUNNER_GROUP="my-group" \
-  -e ORG_RUNNER="true" \
+  -e RUNNER_SCOPE="org" \
   -e ORG_NAME="octokode" \
   -e LABELS="my-label,other-label" \
   -v /var/run/docker.sock:/var/run/docker.sock \
@@ -122,7 +121,7 @@ services:
       RUNNER_TOKEN: someGithubTokenHere
       RUNNER_WORKDIR: /tmp/runner/work
       RUNNER_GROUP: my-group
-      ORG_RUNNER: 'false'
+      RUNNER_SCOPE: 'repo'
       LABELS: linux,x64,gpu
     security_opt:
       # needed on SELinux systems to allow docker container to manage other docker containers
@@ -150,7 +149,7 @@ job "github_runner" {
       RUNNER_NAME_PREFIX = "myrunner"
       RUNNER_WORKDIR     = "/tmp/github-runner-your-repo"
       RUNNER_GROUP       = "my-group"
-      ORG_RUNNER         = "true"
+      RUNNER_SCOPE       = "org"
       ORG_NAME           = "octokode"
       LABELS             = "my-label,other-label"
     }
@@ -201,8 +200,8 @@ spec:
         env:
         - name: ACCESS_TOKEN
           value: foo-access-token
-        - name: ORG_RUNNER
-          value: "true"
+        - name: RUNNER_SCOPE
+          value: "org"
         - name: ORG_NAME
           value: octokode
         - name: LABELS
@@ -256,7 +255,7 @@ docker run -d --restart always --name github-runner \
   -e RUNNER_NAME="foo-runner" \
   -e RUNNER_WORKDIR="/tmp/github-runner-your-repo" \
   -e RUNNER_GROUP="my-group" \
-  -e ORG_RUNNER="true" \
+  -e RUNNER_SCOPE="org" \
   -e ORG_NAME="octokode" \
   -e LABELS="my-label,other-label" \
   -v /var/run/docker.sock:/var/run/docker.sock \
@@ -287,7 +286,7 @@ docker run -d --restart always --name github-runner \
   -e RUNNER_NAME="foo-runner" \
   -e RUNNER_WORKDIR="/tmp/github-runner-your-repo" \
   -e RUNNER_GROUP="my-group" \
-  -e ENTERPRISE_RUNNER="true" \
+  -e RUNNER_SCOPE="enterprise" \
   -e ENTERPRISE_NAME="my-enterprise" \
   -e LABELS="my-label,other-label" \
   -v /var/run/docker.sock:/var/run/docker.sock \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,8 @@ _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 
 if [[ ${ORG_RUNNER} == "true" ]]; then
   _SHORT_URL="https://${_GITHUB_HOST}/${ORG_NAME}"
+elif [[ ${ENTERPRISE_RUNNER} == "true" ]]; then
+  _SHORT_URL="https://${_GITHUB_HOST}/enterprises/${ENTERPRISE_NAME}"
 fi
 
 if [[ -n "${ACCESS_TOKEN}" ]]; then

--- a/token.sh
+++ b/token.sh
@@ -1,40 +1,37 @@
 #!/bin/bash
 
-_ORG_RUNNER=${ORG_RUNNER:-false}
-_ENTERPRISE_RUNNER=${ENTERPRISE_RUNNER:-false}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 
 # If URL is not github.com then use the enterprise api endpoint
 if [[ ${GITHUB_HOST} = "github.com" ]]; then
-    URI="https://api.${_GITHUB_HOST}"
+  URI="https://api.${_GITHUB_HOST}"
 else
-    URI="https://${_GITHUB_HOST}/api/v3"
+  URI="https://${_GITHUB_HOST}/api/v3"
 fi
 
 API_VERSION=v3
 API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
 AUTH_HEADER="Authorization: token ${ACCESS_TOKEN}"
 
-REPO_URL=${REPO_URL:-${URI}}
-_PROTO="$(echo "${REPO_URL}" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
-# shellcheck disable=SC2116
-_URL="$(echo "${REPO_URL/${_PROTO}/}")"
-_PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
-_ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
-_REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+case ${RUNNER_SCOPE} in
+  org*)
+    _FULL_URL="${URI}/orgs/${ORG_NAME}/actions/runners/registration-token"
+    ;;
 
-_FULL_URL="${URI}/repos/${_ACCOUNT}/${_REPO}/actions/runners/registration-token"
-if [[ ${_ORG_RUNNER} == "true" ]]; then
-  [[ -z ${ORG_NAME} ]] && ( echo "ORG_NAME required for org runners"; exit 1 )
-  _FULL_URL="${URI}/orgs/${ORG_NAME}/actions/runners/registration-token"
-  _SHORT_URL="${_PROTO}${_GITHUB_HOST}/${ORG_NAME}"
-elif [[ ${_ENTERPRISE_RUNNER} == "true" ]]; then
-  [[ -z ${ENTERPRISE_NAME} ]] && ( echo "ENTERPRISE_NAME required for enterprise runners"; exit 1 )
-  _FULL_URL="${URI}/enterprises/${ENTERPRISE_NAME}/actions/runners/registration-token"
-  _SHORT_URL="${_PROTO}${_GITHUB_HOST}/enterprises/${ENTERPRISE_NAME}"
-else
-  _SHORT_URL=$REPO_URL
-fi
+  ent*)
+    _FULL_URL="${URI}/enterprises/${ENTERPRISE_NAME}/actions/runners/registration-token"
+    ;;
+
+  *)
+    _PROTO="https://"
+    # shellcheck disable=SC2116
+    _URL="$(echo "${REPO_URL/${_PROTO}/}")"
+    _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
+    _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
+    _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+    _FULL_URL="${URI}/repos/${_ACCOUNT}/${_REPO}/actions/runners/registration-token"
+    ;;
+esac
 
 RUNNER_TOKEN="$(curl -XPOST -fsSL \
   -H "${AUTH_HEADER}" \
@@ -42,4 +39,4 @@ RUNNER_TOKEN="$(curl -XPOST -fsSL \
   "${_FULL_URL}" \
 | jq -r '.token')"
 
-echo "{\"token\": \"${RUNNER_TOKEN}\", \"short_url\": \"${_SHORT_URL}\", \"full_url\": \"${_FULL_URL}\"}"
+echo "{\"token\": \"${RUNNER_TOKEN}\", \"full_url\": \"${_FULL_URL}\"}"

--- a/token.sh
+++ b/token.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 _ORG_RUNNER=${ORG_RUNNER:-false}
+_ENTERPRISE_RUNNER=${ENTERPRISE_RUNNER:-false}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 
 # If URL is not github.com then use the enterprise api endpoint
@@ -27,6 +28,10 @@ if [[ ${_ORG_RUNNER} == "true" ]]; then
   [[ -z ${ORG_NAME} ]] && ( echo "ORG_NAME required for org runners"; exit 1 )
   _FULL_URL="${URI}/orgs/${ORG_NAME}/actions/runners/registration-token"
   _SHORT_URL="${_PROTO}${_GITHUB_HOST}/${ORG_NAME}"
+elif [[ ${_ENTERPRISE_RUNNER} == "true" ]]; then
+  [[ -z ${ENTERPRISE_NAME} ]] && ( echo "ENTERPRISE_NAME required for enterprise runners"; exit 1 )
+  _FULL_URL="${URI}/enterprises/${ENTERPRISE_NAME}/actions/runners/registration-token"
+  _SHORT_URL="${_PROTO}${_GITHUB_HOST}/enterprises/${ENTERPRISE_NAME}"
 else
   _SHORT_URL=$REPO_URL
 fi


### PR DESCRIPTION
Resolves #45, related to #95.

Adds the possibility to register the runner enterprise-wide. Also, as having now multiple scopes, I considered organising a bit the selection of the scope.

Tested in Enterprise environment.
