### PR TITLE
Runner reusage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN chmod +x /actions-runner/install_actions.sh \
   && /actions-runner/install_actions.sh ${GH_RUNNER_VERSION} ${TARGETPLATFORM} \
   && rm /actions-runner/install_actions.sh
 
+ENV CONFIGURED_ACTIONS_RUNNER_FILES_DIR=/actions-runner-files
+
 COPY token.sh entrypoint.sh /
 RUN chmod +x /token.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `RUNNER_GROUP` | Name of the runner group to add this runner to (defaults to the default runner group) |
 | `GITHUB_HOST` | Optional URL of the Github Enterprise server e.g github.mycompany.com. Defaults to `github.com`. |
 | `DISABLE_AUTOMATIC_DEREGISTRATION` | Optional flag to disable signal catching for deregistration. Default is `false`. Any value other than exactly `false` is considered `true`. See [here](https://github.com/myoung34/docker-github-actions-runner/issues/94) |
+| `CONFIGURED_ACTIONS_RUNNER_FILES_DIR` | An optional path *inside a docker container* to mount the directory with the files of the registered runner. It allows avoiding reregistration each the start of the runner. Default is `/actions-runner-files` . |
 
 ## Examples ##
 
@@ -78,6 +79,22 @@ docker run -d --restart always --name github-runner \
   -e RUNNER_GROUP="my-group" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp/github-runner-your-repo:/tmp/github-runner-your-repo \
+  myoung34/github-runner:latest
+```
+
+With the reusage of the registered runner assuming `CONFIGURED_ACTIONS_RUNNER_FILES_DIR=/actions-runner-files` (can be propogated to all other approaches):
+
+```shell
+# per repo
+docker run -d --restart always --name github-runner \
+  -e REPO_URL="https://github.com/myoung34/repo" \
+  -e RUNNER_NAME="foo-runner" \
+  -e RUNNER_TOKEN="footoken" \
+  -e RUNNER_WORKDIR="/tmp/github-runner-your-repo" \
+  -e RUNNER_GROUP="my-group" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/github-runner-your-repo:/tmp/github-runner-your-repo \
+  -v /path/on/host/system:/actions-runner-files
   myoung34/github-runner:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ docker run -d --restart always --name github-runner \
   myoung34/github-runner:latest
 ```
 
-With the reusage of the registered runner assuming `CONFIGURED_ACTIONS_RUNNER_FILES_DIR=/actions-runner-files` (can be propogated to all other approaches):
+Adding the reusage of the registered runner (can be propogated to all other approaches):
 
 ```shell
 # per repo
+export CONFIGURED_ACTIONS_RUNNER_FILES_DIR="/actions-runner-files"
 docker run -d --restart always --name github-runner \
   -e REPO_URL="https://github.com/myoung34/repo" \
   -e RUNNER_NAME="foo-runner" \
@@ -94,11 +95,11 @@ docker run -d --restart always --name github-runner \
   -e RUNNER_GROUP="my-group" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp/github-runner-your-repo:/tmp/github-runner-your-repo \
-  -v /path/on/host/system:/actions-runner-files
+  -v /path/on/host/system:${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}
   myoung34/github-runner:latest
 ```
 
-Or shell wrapper:
+Shell wrapper:
 
 ```shell
 function github-runner {

--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ Adding the reusage of the registered runner (can be propogated to all other appr
 
 ```shell
 # per repo
-export CONFIGURED_ACTIONS_RUNNER_FILES_DIR="/actions-runner-files"
 docker run -d --restart always --name github-runner \
   -e REPO_URL="https://github.com/myoung34/repo" \
   -e RUNNER_NAME="foo-runner" \
   -e RUNNER_TOKEN="footoken" \
   -e RUNNER_WORKDIR="/tmp/github-runner-your-repo" \
   -e RUNNER_GROUP="my-group" \
+  -e CONFIGURED_ACTIONS_RUNNER_FILES_DIR="/actions-runner-files"
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp/github-runner-your-repo:/tmp/github-runner-your-repo \
-  -v /path/on/host/system:${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}
+  -v /path/on/host/system:/actions-runner-files
   myoung34/github-runner:latest
 ```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,6 @@ deregister_runner() {
 run_runner() {
   # shellcheck disable=SC2068
   $@ 
-fi
 }
 
 _DISABLE_AUTOMATIC_DEREGISTRATION=${DISABLE_AUTOMATIC_DEREGISTRATION:-false}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,14 +52,15 @@ case ${RUNNER_SCOPE} in
 esac
 
 # Loading the files from the mounted directory
-if [ -d ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR} ]; then
-  cp -p -r ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/. "/actions-runner"
+if [ -d "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]; then
+  cp -p -r "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/." "/actions-runner"
 fi
 
 if [ -f "/actions-runner/.runner" ]; then
   echo "The runner has already been configured"
   unset ACCESS_TOKEN
   unset RUNNER_TOKEN
+  # shellcheck disable=SC2068
   $@ 
   exit 0
 fi
@@ -83,8 +84,9 @@ echo "Configuring"
 unset RUNNER_TOKEN
 
 # Saving the files in another directory for the possibility to mount them from the host next time
-if [ -d ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR} ]; then
-  cp -p -r "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}
+if [ -d "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]; then
+  # Quoting (even with double-quotes) the regexp brokes the copying
+  cp -p -r "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
 fi
 
 if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,8 @@ deregister_runner() {
   exit
 }
 
-run_runner() {
-  # shellcheck disable=SC2068
-  $@ 
+execute_docker_command() {
+  "$@" 
 }
 
 _DISABLE_AUTOMATIC_DEREGISTRATION=${DISABLE_AUTOMATIC_DEREGISTRATION:-false}
@@ -70,7 +69,7 @@ if [ -f "/actions-runner/.runner" ]; then
   echo "The runner has already been configured"
   unset ACCESS_TOKEN
   unset RUNNER_TOKEN
-  execute_docker_command $@ 
+  execute_docker_command "$@"
   exit 0
 fi
 
@@ -102,4 +101,4 @@ if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
   trap deregister_runner SIGINT SIGQUIT SIGTERM
 fi
 
-execute_docker_command $@ 
+execute_docker_command "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,6 +51,19 @@ case ${RUNNER_SCOPE} in
     ;;
 esac
 
+# Loading the files from the mounted directory
+if [ -d ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR} ]; then
+  cp -p -r ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/. "/actions-runner"
+fi
+
+if [ -f "/actions-runner/.runner" ]; then
+  echo "The runner has already been configured"
+  unset ACCESS_TOKEN
+  unset RUNNER_TOKEN
+  $@ 
+  exit 0
+fi
+
 if [[ -n "${ACCESS_TOKEN}" ]]; then
   _TOKEN=$(bash /token.sh)
   RUNNER_TOKEN=$(echo "${_TOKEN}" | jq -r .token)
@@ -68,6 +81,11 @@ echo "Configuring"
     --replace
 
 unset RUNNER_TOKEN
+
+# Saving the files in another directory for the possibility to mount them from the host next time
+if [ -d ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR} ]; then
+  cp -p -r "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}
+fi
 
 if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
   trap deregister_runner SIGINT SIGQUIT SIGTERM


### PR DESCRIPTION
Allows to avoid the runner reregistration and recreation after restarting.

So the Personal Access Token must be on the machine only for the first run of the runner.

Solves #116 