### PR TITLE
Install git binary package from git-core PPA

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,11 @@
 FROM ubuntu:focal
 LABEL maintainer="myoung34@my.apsu.edu"
 
-ARG GIT_VERSION="2.29.0"
+# TODO: Ubuntu focal (20.04) has git v2.25, but the minimum needed for GitHub
+# Actions runners is v2.29.  For now, we use the git-core PPA to get the latest
+# stable version of git.  When updating to hirsute (21.04) or later, we can
+# remove the git-core PPA below in favor of the regular Ubuntu git package.
+
 ARG DUMB_INIT_VERSION="1.2.2"
 ARG DOCKER_KEY="7EA0A9C3F273FCD8"
 
@@ -42,20 +46,14 @@ RUN apt-get update && \
   && locale-gen en_US.UTF-8 \
   && dpkg-reconfigure locales \
   && c_rehash \
-  && cd /tmp \
-  && curl -sL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz -o git.tgz \
-  && tar zxf git.tgz \
-  && cd git-${GIT_VERSION} \
-  && ./configure --prefix=/usr \
-  && make \
-  && make install \
-  && cd / \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${DOCKER_KEY} \
   && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | awk '{print tolower($0)}')/gpg | apt-key add - \
   && ( add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$(lsb_release -is | awk '{print tolower($0)}') $(lsb_release -cs) stable" ) \
+  && add-apt-repository ppa:git-core/ppa \
   && apt-get update \
   && apt-get install -y docker-ce docker-ce-cli containerd.io --no-install-recommends --allow-unauthenticated \
   && [[ $(lscpu -J | jq -r '.lscpu[] | select(.field == "Vendor ID:") | .data') == "ARM" ]] && echo "Not installing docker-compose. See https://github.com/docker/compose/issues/6831" || ( curl -sL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ) \
   && chmod +x /usr/local/bin/docker-compose \
+  && apt-get install -y git \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /tmp/*


### PR DESCRIPTION
Ubuntu focal (20.04) has git v2.25, but the minimum needed for GitHub
Actions runners is v2.29.  Because of that, git has been built from
source for this Docker image.

However, to save time, we can use the git-core PPA to get the latest
stable version of git.  In the future, when updating to Ubuntu hirsute
(21.04) or later, we can remove the git-core PPA in favor of the regular
Ubuntu git package.

Closes #125