### PR TITLE
Use platform-independent docker-compose instructions in base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -37,6 +37,7 @@ RUN apt-get update && \
     openssh-client \
     locales \
     python3-pip \
+    python3-dev \
     dumb-init \
   && pip3 install --no-cache-dir awscliv2 \
   && locale-gen en_US.UTF-8 \
@@ -55,7 +56,7 @@ RUN apt-get update && \
   && ( add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$(lsb_release -is | awk '{print tolower($0)}') $(lsb_release -cs) stable" ) \
   && apt-get update \
   && apt-get install -y docker-ce docker-ce-cli containerd.io --no-install-recommends --allow-unauthenticated \
-  && [[ $(lscpu -J | jq -r '.lscpu[] | select(.field == "Vendor ID:") | .data') == "ARM" ]] && echo "Not installing docker-compose. See https://github.com/docker/compose/issues/6831" || ( curl -sL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ) \
-  && chmod +x /usr/local/bin/docker-compose \
+  && pip3 install --upgrade pip \
+  && pip3 install docker-compose \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /tmp/*

--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ For more information:
 
 Also, some GitHub Actions Workflow features, like [Job Services](https://docs.github.com/en/actions/guides/about-service-containers), won't be usable and [will result in an error](https://github.com/myoung34/docker-github-actions-runner/issues/61).
 
-### Docker-Compose on ARM ###
-
-Please note `docker-compose` does not currently work on ARM ([see issue](https://github.com/docker/compose/issues/6831)) so it is not installed on ARM based builds here.
-A workaround exists, please see [here](https://github.com/myoung34/docker-github-actions-runner/issues/72#issuecomment-804723656)
-
 ## Docker Artifacts ##
 
 | Container Base | Supported Architectures | Tag Regex | Docker Tags | Description | Notes |


### PR DESCRIPTION
These work for me on all platforms, including arm64, lifting the
limitation on using docker-compose in arm images.

This also fixes a build error for me for the base image, caused when we
tried to unconditionally chmod docker-compose.

Closes #128