### PR TITLE
Make python3 the default version of python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM myoung34/github-runner-base:latest
+FROM joeyparrish/github-runner-base:latest
 LABEL maintainer="myoung34@my.apsu.edu"
 
 ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -38,6 +38,7 @@ RUN apt-get update && \
     locales \
     python3-pip \
     dumb-init \
+  && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
   && pip3 install --no-cache-dir awscliv2 \
   && locale-gen en_US.UTF-8 \
   && dpkg-reconfigure locales \


### PR DESCRIPTION
The base image only installs python3, not python2.  But /usr/bin/env
python should still work, so now we make python3 the default version.

Closes #129