### PR TITLE
Add python2 to base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -37,6 +37,7 @@ RUN apt-get update && \
     openssh-client \
     locales \
     python3-pip \
+    python2 \
     dumb-init \
   && pip3 install --no-cache-dir awscliv2 \
   && locale-gen en_US.UTF-8 \


### PR DESCRIPTION
Since GitHub Actions environments include python2, this improves
compatibility for the docker image.

Closes #129 