### PR TITLE
Make python2 the default python version

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -42,7 +42,7 @@ RUN apt-get update && \
     openssh-client \
     locales \
     python3-pip \
-    python2 \
+    python \
     dumb-init \
   && pip3 install --no-cache-dir awscliv2 \
   && locale-gen en_US.UTF-8 \


### PR DESCRIPTION
It turns out that the "python2" package in Ubuntu doesn't touch
/usr/bin/python.  To get /usr/bin/python pointing to /usr/bin/python2,
you are supposed to install the "python" package.  I didn't realize this
when I made PR #132, and I didn't test thoroughly enough with my own
workflows to realize my mistake.

This corrects the package name to "python", making python2 the default.