### PR TITLE
Fix runner deregistration with ACCESS_TOKEN

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,17 @@
 export RUNNER_ALLOW_RUNASROOT=1
 export PATH=$PATH:/actions-runner
 
+# Un-export these, so that they must be passed explicitly to the environment of
+# any command that needs them.  This may help prevent leaks.
+export -n ACCESS_TOKEN
+export -n RUNNER_TOKEN
+
 deregister_runner() {
   echo "Caught SIGTERM. Deregistering runner"
-  _TOKEN=$(bash /token.sh)
-  RUNNER_TOKEN=$(echo "${_TOKEN}" | jq -r .token)
+  if [[ -n "${ACCESS_TOKEN}" ]]; then
+    _TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
+    RUNNER_TOKEN=$(echo "${_TOKEN}" | jq -r .token)
+  fi
   ./config.sh remove --token "${RUNNER_TOKEN}"
   exit
 }
@@ -54,7 +61,7 @@ esac
 configure_runner() {
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     echo "Obtaining the token of the runnet"
-    _TOKEN=$(bash /token.sh)
+    _TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
     RUNNER_TOKEN=$(echo "${_TOKEN}" | jq -r .token)
   fi
 
@@ -100,9 +107,6 @@ fi
 if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
   trap deregister_runner SIGINT SIGQUIT SIGTERM
 fi
-
-unset ACCESS_TOKEN
-unset RUNNER_TOKEN
 
 # Container's command (CMD) execution
 "$@"


### PR DESCRIPTION
This fixes runner deregistration, which needs to have ACCESS_TOKEN still
defined to fetch a fresh RUNNER_TOKEN for deregistration.

The original purpose of unsetting the variables would seem to be for
security, to make sure they unavailable to the jobs running in the
container.  Unexporting the variables achieves the same goal, but leaves
them available to the entrypoint later when it runs the deregistration
process.