### PR TITLE
feat: Ephemeral mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN chmod +x /actions-runner/install_actions.sh \
   && /actions-runner/install_actions.sh ${GH_RUNNER_VERSION} ${TARGETPLATFORM} \
   && rm /actions-runner/install_actions.sh
 
-COPY token.sh entrypoint.sh /
-RUN chmod +x /token.sh /entrypoint.sh
+COPY token.sh entrypoint.sh ephemeral-runner.sh /
+RUN chmod +x /token.sh /entrypoint.sh /ephemeral-runner.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/actions-runner/bin/runsvc.sh"]

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ docker run -d --restart always --name github-runner \
 
 ## Ephemeral mode
 
-GitHub's hosted runners are completely ephemeral.  You can `sudo rm -rf /` without breaking all future jobs.
+GitHub's hosted runners are completely ephemeral.  You can remove all its data without breaking all future jobs.
 
 To achieve the same resilience in a self-hosted runner:
   1. override the command for your runner with `/ephemeral-runner.sh` (which will terminate after one job executes)

--- a/ephemeral-runner.sh
+++ b/ephemeral-runner.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "*** Starting ephemeral runner. ***"
+/actions-runner/run.sh --once
+rv=$?
+
+# See exit code constants in the runner source here:
+# https://github.com/actions/runner/blob/be96323/src/Runner.Common/Constants.cs#L135
+if [[ $rv == 4 ]]; then
+  # The runner software was updated.
+  echo "*** Software update detected. ***"
+
+  echo "*** Waiting for update to complete. ***"
+  # Hard-coded sleep.  Without some delay, the update is still in progress in
+  # the background, leading to failures when we re-launch.
+  sleep 10
+
+  # Now add an adaptive delay, where we loop and check if the Runner is usable
+  # yet.  As soon as it is, break.
+  for i in $(seq 10); do
+    if /actions-runner/bin/Runner.Listener --version &>/dev/null; then
+      break
+    fi
+
+    echo "*** Update still in progress... ***"
+    sleep 5
+  done
+
+  # Now re-launch the script.
+  echo "*** Re-launching runner. ***"
+  exec "$0"
+fi
+
+# For any other return value, let the script and the Docker container terminate.
+echo "*** Exit code $rv ***"
+exit $rv


### PR DESCRIPTION
This adds a script called ephemeral-runner.sh, which users can call as an explicit command to enable ephemeral mode.  It will register the runner with `--once`, and will terminate after a single job has been executed.

If the runner terminates with an exit code indicating that a software update has been installed (instead of running a job), then the script will wait for the update to complete and run itself again.

Combined with a service definition that restarts automatically, this allows for completely ephemeral operation of a self-hosted runner, in line with GitHub's own hosted runners.

Closes #137