### PR TITLE
Fix #142 - building on Sid

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -51,9 +51,14 @@ RUN apt-get update && \
   && make \
   && make install \
   && cd / \
+  # Determine the Distro name (Debian, Ubuntu, etc)
+  && distro=$(lsb_release -is | awk '{print tolower($0)}') \
+  # Determine the Distro version (bullseye, xenial, etc)
+  # Note: sid is aliased to bullseye, because Docker doesn't have a matching apt repo
   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${DOCKER_KEY} \
-  && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | awk '{print tolower($0)}')/gpg | apt-key add - \
-  && ( add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$(lsb_release -is | awk '{print tolower($0)}') $(lsb_release -cs) stable" ) \
+  && curl -fsSL https://download.docker.com/linux/${distro}/gpg | apt-key add - \
+  && version=$(lsb_release -cs | awk '{gsub("sid", "bullseye"); print $0}') \
+  && ( add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/${distro} ${version} stable" ) \
   && apt-get update \
   && apt-get install -y docker-ce docker-ce-cli containerd.io --no-install-recommends --allow-unauthenticated \
   && [[ $(lscpu -J | jq -r '.lscpu[] | select(.field == "Vendor ID:") | .data') == "ARM" ]] && echo "Not installing docker-compose. See https://github.com/docker/compose/issues/6831" || ( curl -sL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ) \


### PR DESCRIPTION
Added `distro` and `version` variables to use in the apt repo config, so it's better future-proof as well.