### PR TITLE
Properly enable locale

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,13 +12,14 @@ ARG DOCKER_KEY="7EA0A9C3F273FCD8"
 
 ENV DOCKER_COMPOSE_VERSION="1.27.4"
 ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US:en
-ENV LC_ALL=en_US.UTF-8 
+ENV LANGUAGE=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3003,DL4001
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
+RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
     awscli \
     curl \
     tar \
@@ -45,8 +46,6 @@ RUN apt-get update && \
     python \
     dumb-init \
   && pip3 install --no-cache-dir awscliv2 \
-  && locale-gen en_US.UTF-8 \
-  && dpkg-reconfigure locales \
   && c_rehash \
   && cd /tmp \
   && curl -sL https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz -o git.tgz \


### PR DESCRIPTION
This PR fixes the `/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)` warnings on Debian and slightly improves Docker image generation speed.
Tested generating images for Debian Buster and Ubuntu Focal.