### PR TITLE
Fix deregistration hijacking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY token.sh entrypoint.sh ephemeral-runner.sh /
 RUN chmod +x /token.sh /entrypoint.sh /ephemeral-runner.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/actions-runner/bin/runsvc.sh"]
+CMD ["./bin/Runner.Listener", "run", "--startuptype", "service"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,7 +105,7 @@ if [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
 fi
 
 if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
-  trap deregister_runner SIGINT SIGQUIT SIGTERM
+  trap deregister_runner SIGINT SIGQUIT SIGTERM INT TERM QUIT
 fi
 
 # Container's command (CMD) execution


### PR DESCRIPTION
This resolves #141 and #139

[runsvc.sh](https://github.com/actions/runner/blob/be9632302ceef50bfb36ea998cea9c94c75e5d4d/src/Misc/layoutbin/runsvc.sh) hijacks a bunch of the signals and calls `./externals/node12/bin/node ./bin/RunnerService.js` [here](https://github.com/actions/runner/blob/0a6c34669cbd7c5da3cebd437f07bf872adb7559/src/Misc/layoutbin/RunnerService.js#L90) which also tries to handle signals

All RunnerService.js does is call `bin/Runner.Listener` so Im simplifying this by avoiding entrypoint -> runsvc -> RunnerService -> Runner.Listener by just calling `Runner.Listener` directly in entrypoint.sh via CMD