### PR TITLE
Fix small typo in entrypoint.sh log output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ esac
 
 configure_runner() {
   if [[ -n "${ACCESS_TOKEN}" ]]; then
-    echo "Obtaining the token of the runnet"
+    echo "Obtaining the token of the runner"
     _TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
     RUNNER_TOKEN=$(echo "${_TOKEN}" | jq -r .token)
   fi


### PR DESCRIPTION
Extremely small and practically pointless typo fix. But I just saw it in the output and it annoyed me a bit 😃

![image](https://user-images.githubusercontent.com/529614/134335285-32748a82-5bbe-4084-b6ac-5f7453984734.png)
