### PR TITLE
Support --ephemeral option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `GITHUB_HOST` | Optional URL of the Github Enterprise server e.g github.mycompany.com. Defaults to `github.com`. |
 | `DISABLE_AUTOMATIC_DEREGISTRATION` | Optional flag to disable signal catching for deregistration. Default is `false`. Any value other than exactly `false` is considered `true`. See [here](https://github.com/myoung34/docker-github-actions-runner/issues/94) |
 | `CONFIGURED_ACTIONS_RUNNER_FILES_DIR` | Path to use for runner data. It allows avoiding reregistration each the start of the runner. No default value. |
+| `EPHEMERAL` | Optional flag to configure runner with [`--ephemeral` option](https://docs.github.com/en/actions/hosting-your-own-runners/autoscaling-with-self-hosted-runners#using-ephemeral-runners-for-autoscaling). Ephemeral runners are suitable for autoscaling. |
 
 ## Examples ##
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,13 @@ configure_runner() {
     RUNNER_TOKEN=$(echo "${_TOKEN}" | jq -r .token)
   fi
 
+  if [ -n "${EPHEMERAL}" ]; then
+    echo "Ephemeral option is enabled"
+    _EPHEMERAL="--ephemeral"
+  else
+    _EPHEMERAL=""
+  fi
+
   echo "Configuring"
   ./config.sh \
       --url "${_SHORT_URL}" \
@@ -74,7 +81,7 @@ configure_runner() {
       --labels "${_LABELS}" \
       --runnergroup "${_RUNNER_GROUP}" \
       --unattended \
-      --replace
+      --replace "${_EPHEMERAL}"
 }
 
 


### PR DESCRIPTION
fix: #148 

Add `EPHEMERAL` environment variable to support `--ephemeral` option.

@joeyparrish refers also need to fix ephemeral_runner.sh, but it seems no problem with using default ENTRYPOINT and CMD.
I checked using this docker run command.

```bash
docker run --rm --name github-runner \
  -e RUNNER_NAME_PREFIX="ephemeral-docker" \
  -e ACCESS_TOKEN="${RUNNER_PAT}" \
  -e RUNNER_SCOPE="org" \
  -e ORG_NAME="${ORG}" \
  -e LABELS="container" \
  -e EPHEMERAL=1 \
  -v /var/run/docker.sock:/var/run/docker.sock \
  kesin11/docker-github-actions-runner:latest
```