### PR TITLE
Fix configure command when EPHEMERAL is disabled

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,7 +81,7 @@ configure_runner() {
       --labels "${_LABELS}" \
       --runnergroup "${_RUNNER_GROUP}" \
       --unattended \
-      --replace "${_EPHEMERAL}"
+      --replace ${_EPHEMERAL}
 }
 
 


### PR DESCRIPTION
When run with no `EPHEMERAL` env, `Unrecognized command-line input arguments: 'replace'. For usage refer to: .\config.cmd --help or ./config.sh --help`  message appeared at entrypoint.sh .

When `EPHEMERAL` env is disabled, `--replace "${_EPHEMERAL}"` is replaced to `--replace ''` so it is treated as part of `--replace` option. This bug comes from #161.