### PR TITLE
fixing HTTP/1.1 411 Length Required

### DIFF
--- a/token.sh
+++ b/token.sh
@@ -12,6 +12,7 @@ fi
 API_VERSION=v3
 API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
 AUTH_HEADER="Authorization: token ${ACCESS_TOKEN}"
+CONTENT_LENGTH_HEADER="Content-Length: 0"
 
 case ${RUNNER_SCOPE} in
   org*)
@@ -34,6 +35,7 @@ case ${RUNNER_SCOPE} in
 esac
 
 RUNNER_TOKEN="$(curl -XPOST -fsSL \
+  -H "${CONTENT_LENGTH_HEADER}" \
   -H "${AUTH_HEADER}" \
   -H "${API_HEADER}" \
   "${_FULL_URL}" \


### PR DESCRIPTION
Somehow our Github enterprise server returns 411 when the "Content-Lenght" header is not set. 

The complete error message is (using curl -v): 
```
HTTP/1.1 411 Length Required
< Content-Type: text/html; charset=us-ascii
< Server: Microsoft-HTTPAPI/2.0
< Date: Thu, 06 Jan 2022 15:36:55 GMT
< Connection: close
< Content-Length: 344
<
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
<HTML><HEAD><TITLE>Length Required</TITLE>
<META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
<BODY><h2>Length Required</h2>
<hr><p>HTTP Error 411. The request must be chunked or have a content length.</p>
</BODY></HTML>
```

By setting this Header explicitely, this error does no longer occur.