### PR TITLE
Update AWS CLI to v2

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -18,7 +18,6 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${GIT_CORE_PPA_KEY} \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-    awscli \
     curl \
     tar \
     unzip \
@@ -46,7 +45,9 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && ( apt-get install -y --no-install-recommends git || apt-get install -t stable -y --no-install-recommends git || apt-get install -y --no-install-recommends git=1:2.33.1-0ppa1~ubuntu18.04.1 git-man=1:2.33.1-0ppa1~ubuntu18.04.1 ) \
   && ( [[ $(apt-cache search -n liblttng-ust0 | awk '{print $1}') == "liblttng-ust0" ]] && apt-get install -y --no-install-recommends liblttng-ust0 || : ) \
   && ( [[ $(apt-cache search -n liblttng-ust1 | awk '{print $1}') == "liblttng-ust1" ]] && apt-get install -y --no-install-recommends liblttng-ust1 || : ) \
-  && pip3 install --no-cache-dir awscliv2 \
+  && curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" \
+  && unzip awscliv2.zip -d /tmp/ \
+  && /tmp/aws/install \
   # Determine the Distro name (Debian, Ubuntu, etc)
   && distro=$(lsb_release -is | awk '{print tolower($0)}') \
   # Determine the Distro version (bullseye, xenial, etc)


### PR DESCRIPTION
AWS no longer pushes the AWS CLI to PyPi and the version bundled with the runner is getting quite old. This PR pulls the latest AWS CLI v2 directly from AWS. As of this time, the official runners are running AWS CLI 2.4.12.