### PR TITLE
fix(ephemeral-runner): Replace once with ephemeral

### DIFF
--- a/ephemeral-runner.sh
+++ b/ephemeral-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "*** Starting ephemeral runner. ***"
-/actions-runner/run.sh --once
+/actions-runner/run.sh --ephemeral
 rv=$?
 
 # See exit code constants in the runner source here:


### PR DESCRIPTION
When running the `ephemeral-runner.sh` there is a deprecation warning.
Better to solve it sooner than later...
```
Warning: '--once' is going to be deprecated in the future, please consider using '--ephemeral' during runner registration.
```