### PR TITLE
fix(README.md): Fix the service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,12 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=-/usr/bin/docker pull myoung34/github-runner:latest
-ExecStart=/usr/bin/docker run --rm --env-file /etc/ephemeral-github-actions-runner.env --name %n myoung34/github-runner:latest /ephemeral-runner.sh
+ExecStart=/usr/bin/docker run --rm \
+                              --env-file /etc/ephemeral-github-actions-runner.env \
+                              -v /var/run/docker.sock:/var/run/docker.sock \
+                              --name %n myoung34/github-runner:latest \
+                              /ephemeral-runner.sh
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I was able to get everything up and running and it looks good aside from a small gotcha.

While setting up an ephemeral systemd service it seemed that I still needed to mount the `/var/run/docker.sock`.

I am a pretty big fan of copy pasta and this may save a few google queries for "cannot connect to the docker daemon at unix:///var/run/docker.sock. is the docker daemon running?"

I guess some issue with docker in docker.

Anyways, just wondering if it would be useful, no need to merge if it doesn't make sense.