### PR TITLE
Add proxy env variable passthru on sudo

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -41,7 +41,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
     python3-setuptools \
     python3 \
     dumb-init \
-  && sed -e 's/Defaults env_reset/Defaults  env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers \
+  && sed -e 's/Defaults.*env_reset/Defaults env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers \
   && echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu $([[ $(grep -E '^ID=' /etc/os-release | sed 's/.*=//g') == "ubuntu" ]] && (grep VERSION_CODENAME /etc/os-release | sed 's/.*=//g') || echo bionic) main>/etc/apt/sources.list.d/git-core.list \
   && apt-get update \
   && ( apt-get install -y --no-install-recommends git || apt-get install -t stable -y --no-install-recommends git || apt-get install -y --no-install-recommends git=1:2.33.1-0ppa1~ubuntu18.04.1 git-man=1:2.33.1-0ppa1~ubuntu18.04.1 ) \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -41,6 +41,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
     python3-setuptools \
     python3 \
     dumb-init \
+  && sed -e 's/Defaults env_reset/Defaults  env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers \
   && echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu $([[ $(grep -E '^ID=' /etc/os-release | sed 's/.*=//g') == "ubuntu" ]] && (grep VERSION_CODENAME /etc/os-release | sed 's/.*=//g') || echo bionic) main>/etc/apt/sources.list.d/git-core.list \
   && apt-get update \
   && ( apt-get install -y --no-install-recommends git || apt-get install -t stable -y --no-install-recommends git || apt-get install -y --no-install-recommends git=1:2.33.1-0ppa1~ubuntu18.04.1 git-man=1:2.33.1-0ppa1~ubuntu18.04.1 ) \


### PR DESCRIPTION
If you use "sudo" in the workflow file while behind a proxy, the environment variables passed into the container on creation will be lost since sudo current resets the environment. Update /etc/sudoers to allow the *_proxy and *_PROXY variables to be passed thru so proxy configuration is not lost.

This time with missing `\`.