### PR TITLE
Clean-up github actions to use official actions

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -10,56 +10,64 @@ on:
   schedule:
     - cron:  '0 22 * * *'
 
-
 jobs:
   ubuntu_base_latest_deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile.base -t ${ORG}/github-runner-base:latest --output "type=image,push=true" --platform linux/amd64,linux/arm64 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.base
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner-base:latest
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   ubuntu_base_bionic_deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Copy Dockerfile
-      run: cp Dockerfile.base Dockerfile.base.ubuntu-bionic; sed -i.bak 's/FROM.*/FROM ubuntu:bionic/' Dockerfile.base.ubuntu-bionic
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile.base.ubuntu-bionic -t ${ORG}/github-runner-base:ubuntu-bionic --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Copy Dockerfile
+        run: cp Dockerfile.base Dockerfile.base.ubuntu-bionic; sed -i.bak 's/FROM.*/FROM ubuntu:bionic/' Dockerfile.base.ubuntu-bionic
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.base.ubuntu-bionic
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner-base:ubuntu-bionic
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   debian_base_deploy:
     runs-on: ubuntu-latest
@@ -68,25 +76,29 @@ jobs:
         release: [bullseye, sid]
       fail-fast: false
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Copy Dockerfile
-      run: cp Dockerfile.base Dockerfile.base.debian-${{ matrix.release }}; sed -i.bak 's/FROM.*/FROM debian:${{ matrix.release }}/' Dockerfile.base.debian-${{ matrix.release }}
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile.base.debian-${{ matrix.release }} -t ${ORG}/github-runner-base:debian-${{ matrix.release }} --output "type=image,push=true" --platform linux/amd64,linux/arm64,linux/arm/v7 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Copy Dockerfile
+        run: cp Dockerfile.base Dockerfile.base.debian-${{ matrix.release }}; sed -i.bak 's/FROM.*/FROM debian:${{ matrix.release }}/' Dockerfile.base.debian-${{ matrix.release }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.base.debian-${{ matrix.release }}
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner-base:debian-${{ matrix.release }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,51 +14,60 @@ jobs:
   ubuntu_latest_deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile -t ${ORG}/github-runner:latest --output "type=image,push=true" --platform linux/amd64,linux/arm64 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner:latest
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   ubuntu_bionic_deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Copy Dockerfile
-      run: cp Dockerfile Dockerfile.ubuntu-bionic; sed -i.bak "s/FROM.*/FROM ${ORG}\/github-runner-base:ubuntu-bionic/" Dockerfile.ubuntu-bionic
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile.ubuntu-bionic -t ${ORG}/github-runner:ubuntu-bionic --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Copy Dockerfile
+        run: cp Dockerfile Dockerfile.ubuntu-bionic; sed -i.bak "s/FROM.*/FROM ${ORG}\/github-runner-base:ubuntu-bionic/" Dockerfile.ubuntu-bionic
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.ubuntu-bionic
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner:ubuntu-bionic
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   debian_deploy:
     runs-on: ubuntu-latest
@@ -67,25 +76,29 @@ jobs:
         release: [bullseye, sid]
       fail-fast: false
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Copy Dockerfile
-      run: cp Dockerfile Dockerfile.debian-${{ matrix.release }}; sed -i.bak "s/FROM.*/FROM ${ORG}\/github-runner-base:debian-${{ matrix.release }}/" Dockerfile.debian-${{ matrix.release }}
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile.debian-${{ matrix.release }} -t ${ORG}/github-runner:debian-${{ matrix.release }} --output "type=image,push=true" --platform linux/amd64,linux/arm64,linux/arm/v7 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Copy Dockerfile
+        run: cp Dockerfile Dockerfile.debian-${{ matrix.release }}; sed -i.bak "s/FROM.*/FROM ${ORG}\/github-runner-base:debian-${{ matrix.release }}/" Dockerfile.debian-${{ matrix.release }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.debian-${{ matrix.release }}
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner:debian-${{ matrix.release }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,56 +25,67 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: get version
-      run: echo 'TAG='${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile -t ${ORG}/github-runner:${TAG} --output "type=image,push=true" --platform linux/amd64,linux/arm64 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: get version
+        run: echo 'TAG='${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner:${TAG}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   ubuntu_bionic_tag:
     runs-on: ubuntu-latest
     needs: create-release
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: get version
-      run: echo 'TAG='${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Copy Dockerfile
-      run: cp Dockerfile Dockerfile.ubuntu-bionic; sed -i.bak "s/FROM.*/FROM ${ORG}\/github-runner-base:ubuntu-bionic/" Dockerfile.ubuntu-bionic
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile.ubuntu-bionic -t ${ORG}/github-runner:${TAG}-ubuntu-bionic --output "type=image,push=true" --platform linux/amd64,linux/arm/v7,linux/arm64 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: get version
+        run: echo 'TAG='${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Copy Dockerfile
+        run: cp Dockerfile Dockerfile.ubuntu-bionic; sed -i.bak "s/FROM.*/FROM ${ORG}\/github-runner-base:ubuntu-bionic/" Dockerfile.ubuntu-bionic
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.ubuntu-bionic
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner:${TAG}-ubuntu-bionic
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   debian_tag:
     runs-on: ubuntu-latest
@@ -84,27 +95,31 @@ jobs:
       fail-fast: false
     needs: create-release
     steps:
-    - name: Copy Repo Files
-      uses: actions/checkout@master
-    - name: get version
-      run: echo 'TAG='${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
-    - name: Get GitHub organization or user
-      run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v1
-      with:
-        buildx-version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-    - name: Copy Dockerfile
-      run: cp Dockerfile Dockerfile.debian-${{ matrix.release }}; sed -i.bak "s/FROM.*/FROM ${ORG}\/github-runner-base:debian-${{ matrix.release }}/" Dockerfile.debian-${{ matrix.release }}
-    - name: Login
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_TOKEN }}
-    - name: Build
-      uses: nick-invision/retry@v2
-      with:
-        max_attempts: 3
-        retry_on: error
-        timeout_minutes: 120
-        command: docker buildx build -f Dockerfile.debian-${{ matrix.release }} -t ${ORG}/github-runner:${TAG}-debian-${{ matrix.release }} --output "type=image,push=true" --platform linux/amd64,linux/arm64,linux/arm/v7 .
+      - name: Copy Repo Files
+        uses: actions/checkout@master
+      - name: get version
+        run: echo 'TAG='${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(dirname ${GITHUB_REPOSITORY}) >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Copy Dockerfile
+        run: cp Dockerfile Dockerfile.debian-${{ matrix.release }}; sed -i.bak "s/FROM.*/FROM ${ORG}\/github-runner-base:debian-${{ matrix.release }}/" Dockerfile.debian-${{ matrix.release }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.debian-${{ matrix.release }}
+          pull: true
+          push: true
+          tags: ${ORG}/github-runner:${TAG}-debian-${{ matrix.release }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Update github actions to use official actions.

- Use standard YAML indenting.
- Replace [crazy-max/ghaction-docker-buildx ](https://github.com/crazy-max/ghaction-docker-buildx)with [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action) + [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)
- Replace custom docker login with[ docker/login-action](https://github.com/docker/login-action)
- Replace custom docker build/push with [docker/build-push-action](https://github.com/docker/build-push-action)
- Use docker/build-push-action Github Action Caching 