### PR TITLE
option --ephemeral not supported with /actions-runner/run.sh

### DIFF
--- a/ephemeral-runner.sh
+++ b/ephemeral-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "*** Starting ephemeral runner. ***"
-/actions-runner/run.sh --ephemeral
+/actions-runner/run.sh
 rv=$?
 
 # See exit code constants in the runner source here:


### PR DESCRIPTION
when running `myoung34/github-runner:latest` with command set to `/ephemeral-runner.sh`, the following error occurs:

```
Unrecognized command-line input arguments for command run: 'ephemeral'. For usage refer to: .\config.cmd --help or ./config.sh --help
```

`--ephemeral` is passed to config.sh in the entrypoint