### PR TITLE
Add support for buildah-build and podman-push actions

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -42,6 +42,8 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
     python3 \
     dumb-init \
     podman \
+    buildah \
+    skopeo \
   && sed -e 's/Defaults.*env_reset/Defaults env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers \
   && echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu $([[ $(grep -E '^ID=' /etc/os-release | sed 's/.*=//g') == "ubuntu" ]] && (grep VERSION_CODENAME /etc/os-release | sed 's/.*=//g') || echo bionic) main>/etc/apt/sources.list.d/git-core.list \
   && apt-get update \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -41,6 +41,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
     python3-setuptools \
     python3 \
     dumb-init \
+    podman \
   && sed -e 's/Defaults.*env_reset/Defaults env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers \
   && echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu $([[ $(grep -E '^ID=' /etc/os-release | sed 's/.*=//g') == "ubuntu" ]] && (grep VERSION_CODENAME /etc/os-release | sed 's/.*=//g') || echo bionic) main>/etc/apt/sources.list.d/git-core.list \
   && apt-get update \


### PR DESCRIPTION
Hi,
I've been using this self-hosted GitHub runner and I need podman/buildah/skopeo to be able to execute some actions like:
https://github.com/redhat-actions/buildah-build
https://github.com/redhat-actions/push-to-registry

Also, although this patch is a fix for this issue, I believe that will be wise to improve the base image with the official ubuntu software installed in GitHub virtual environment image.
You could check it at:
https://github.com/actions/virtual-environments/tree/main/images/linux/scripts/installers

Best regards