### PR TITLE
Check to see if not running as root

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,7 @@ configure_runner() {
       ${_AUTO_UPDATE}
 
   [[ ! -d "${_RUNNER_WORKDIR}" ]] && mkdir "${_RUNNER_WORKDIR}"
-  
+
   [[ $(id -u) -eq 0 ]] && /usr/bin/chown -R runner ${_RUNNER_WORKDIR} /opt/hostedtoolcache/ /actions-runner || :
 }
 
@@ -133,7 +133,10 @@ fi
 
 
 if [[ ${_RUN_AS_ROOT} == "true" ]]; then
-  [[ $(id -u) -eq 0 ]] && ( "$@" ) || ( echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overriden and is not running as root"; exit 1 )
+  if [[ $(id -u) -ne 0 ]]; then
+    echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root. Currently running as $(whoami)"
+    exit 1
+  fi
 else
   [[ $(id -u) -eq 0 ]] && ( /usr/sbin/gosu runner "$@" ) || ( "$@" )
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,7 +139,6 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
     echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root, but UID '$(id -u)'"
     exit 1
   fi
-    echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root. Currently running as $(whoami)"
     exit 1
   fi
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -140,5 +140,9 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
     exit 1
   fi
 else
-  [[ $(id -u) -eq 0 ]] && ( /usr/sbin/gosu runner "$@" ) || ( "$@" )
+  if [[ $(id -u) -eq 0 ]]; then
+    /usr/sbin/gosu runner "$@"
+  else
+    "$@"
+  fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,7 +139,6 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
     echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root, but UID '$(id -u)'"
     exit 1
   fi
-  fi
 else
   [[ $(id -u) -eq 0 ]] && ( /usr/sbin/gosu runner "$@" ) || ( "$@" )
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,7 +139,6 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
     echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root, but UID '$(id -u)'"
     exit 1
   fi
-    exit 1
   fi
 else
   [[ $(id -u) -eq 0 ]] && ( /usr/sbin/gosu runner "$@" ) || ( "$@" )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -133,7 +133,12 @@ fi
 
 
 if [[ ${_RUN_AS_ROOT} == "true" ]]; then
-  if [[ $(id -u) -ne 0 ]]; then
+  if [[ $(id -u) -eq 0 ]]; then
+    "$@"
+  else
+    echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root, but UID '$(id -u)'"
+    exit 1
+  fi
     echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root. Currently running as $(whoami)"
     exit 1
   fi


### PR DESCRIPTION
Looking at this bit of code it was checking to see if running as root, but the message says not running as root, I think the logic is backwards.

I also ran shellcheck on the file and it made some comments about the logic use generally, but I don't want to tinker too much:

```
In entrypoint.sh line 136:
  [[ $(id -u) -ne 0 ]] && ( "$@" ) || ( echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overriden and is not running as root"; exit 1 )
                       ^-- SC2015 (info): Note that A && B || C is not if-then-else. C may run when A is true.


In entrypoint.sh line 138:
  [[ $(id -u) -eq 0 ]] && ( /usr/sbin/gosu runner "$@" ) || ( "$@" )
                       ^-- SC2015 (info): Note that A && B || C is not if-then-else. C may run when A is true.
```

Closes #233 