### PR TITLE
Fix ephemeral support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,6 @@ _LABELS=${LABELS:-default}
 _RUNNER_GROUP=${RUNNER_GROUP:-Default}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 _RUN_AS_ROOT=${RUN_AS_ROOT:="true"}
-_EPHEMERAL=""
 
 # ensure backwards compatibility
 if [[ -z $RUNNER_SCOPE ]]; then
@@ -62,6 +61,7 @@ case ${RUNNER_SCOPE} in
 esac
 
 configure_runner() {
+  ARGS=()
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     echo "Obtaining the token of the runner"
     _TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
@@ -71,14 +71,12 @@ configure_runner() {
   # shellcheck disable=SC2153
   if [ -n "${EPHEMERAL}" ]; then
     echo "Ephemeral option is enabled"
-    _EPHEMERAL="--ephemeral"
+    ARGS+=("--ephemeral")
   fi
 
   if [ -n "${DISABLE_AUTO_UPDATE}" ]; then
     echo "Disable auto update option is enabled"
-    _AUTO_UPDATE="--disableupdate"
-  else
-    _AUTO_UPDATE=""
+    ARGS+=("--disableupdate")
   fi
 
   echo "Configuring"
@@ -91,8 +89,7 @@ configure_runner() {
       --runnergroup "${_RUNNER_GROUP}" \
       --unattended \
       --replace \
-      "${_EPHEMERAL}" \
-      "${_AUTO_UPDATE}"
+      "${ARGS[@]}"
 
   [[ ! -d "${_RUNNER_WORKDIR}" ]] && mkdir "${_RUNNER_WORKDIR}"
 


### PR DESCRIPTION
The quotes added in 08608da938e5f565c4a9f38a793a2d29ad5db1bd cause `ephemeral` to evaluate as false when `DISABLE_AUTO_UPDATE` was not set.

This is explained in details in #249. This diff changes the logic to use an array where extra parameters are being added.
When calling config.sh, the array is expanded.

Testing:
../self_hosted_runner.env contains
```
EPHEMERAL=true
```

Before: https://gist.github.com/chantra/443dfaa60d964d938bcb1c020781ca00 we can see multiple jobs got scheduled on the runner

After: https://gist.github.com/chantra/061dc471c63964c01a2e3733a53bd3ec we can see that when the job finished, the container shutdown.

After with DISABLE_AUTO_UPDATE set: https://gist.github.com/chantra/df0102c7340b8f6bfd458ec56d9fa29c

Also adding `set -x` before the call to `config.sh` revealed the arguments were correctly added.

Fixes #249