### PR TITLE
Add support for GitHub app authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,9 @@ on:
   schedule:
     - cron:  '59 23 * * *'
 
-permissions: 
+permissions:
   contents: read
-  packages: write 
+  packages: write
 
 jobs:
   ubuntu_latest_deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN chmod +x /actions-runner/install_actions.sh \
   && rm /actions-runner/install_actions.sh \
   && chown runner /_work /actions-runner /opt/hostedtoolcache
 
-COPY token.sh entrypoint.sh /
-RUN chmod +x /token.sh /entrypoint.sh
+COPY token.sh entrypoint.sh app_token.sh /
+RUN chmod +x /token.sh /entrypoint.sh /app_token.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["./bin/Runner.Listener", "run", "--startuptype", "service"]

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Please read [the contributing guidelines](https://github.com/myoung34/docker-git
 
 ### Security ###
 
-It is known that currently tokens (ACCESS_TOKEN / RUNNER_TOKEN ) are not safe from exfiltration.
+It is known that currently tokens (ACCESS_TOKEN / RUNNER_TOKEN / APP_ID / APP_PRIVATE_KEY ) are not safe from exfiltration.
 If you are using this runner make sure that any workflow changes are gated by a verification process (in the actions settings) so that malicious PR's cannot exfiltrate these.
+
+If using APP_ID and APP_PRIVATE_KEY, you can prevent those from being accessible within the container, see the [note on Github App runner](#a-note-on-github-app-runner).
 
 ### Docker Support ###
 
@@ -56,7 +58,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `RUN_AS_ROOT` | Boolean to run as root. If `true`: will run as root. If `True` and the user is overridden it will error. If any other value it will run as the `runner` user and allow an optional override. Default is `true` |
 | `RUNNER_NAME` | The name of the runner to use. Supercedes (overrides) `RUNNER_NAME_PREFIX` |
 | `RUNNER_NAME_PREFIX` | A prefix for a randomly generated name (followed by a random 13 digit string). You must not also provide `RUNNER_NAME`. Defaults to `github-runner` |
-| `ACCESS_TOKEN` | A [github PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to use to generate `RUNNER_TOKEN` dynamically at container start. Not using this requires a valid `RUNNER_TOKEN` |
+| `ACCESS_TOKEN` | A [github PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to use to generate `RUNNER_TOKEN` dynamically at container start. Not using this requires a valid `RUNNER_TOKEN`, or a valid `APP_ID` and `APP_PRIVATE_KEY` pair. |
 | `RUNNER_SCOPE` | The scope the runner will be registered on. Valid values are `repo`, `org` and `ent`. For 'org' and 'enterprise', `ACCESS_TOKEN` is required and `REPO_URL` is unnecessary. If 'org', requires `ORG_NAME`; if 'enterprise', requires `ENTERPRISE_NAME`. Default is 'repo'. |
 | `ORG_NAME` | The organization name for the runner to register under. Requires `RUNNER_SCOPE` to be 'org'. No default value. |
 | `ENTERPRISE_NAME` | The enterprise name for the runner to register under. Requires `RUNNER_SCOPE` to be 'enterprise'. No default value. |
@@ -70,3 +72,62 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `CONFIGURED_ACTIONS_RUNNER_FILES_DIR` | Path to use for runner data. It allows avoiding reregistration each the start of the runner. No default value. |
 | `EPHEMERAL` | Optional flag to configure runner with [`--ephemeral` option](https://docs.github.com/en/actions/hosting-your-own-runners/autoscaling-with-self-hosted-runners#using-ephemeral-runners-for-autoscaling). Ephemeral runners are suitable for autoscaling. |
 | `DISABLE_AUTO_UPDATE` | Optional environment variable to [disable auto updates](https://github.blog/changelog/2022-02-01-github-actions-self-hosted-runners-can-now-disable-automatic-updates/). Auto updates are enabled by default to preserve past behavior. Any value is considered truthy and will disable them. |
+| `APP_ID` | If using a GitHub app to authenticate the runner, this is the ID of such GitHub app. `APP_PRIVATE_KEY` must also be set. |
+| `APP_PRIVATE_KEY` | If using a Github app to authenticate the runner, this is the content of the secret key, in PEM format to use by the app. `APP_ID` must also be set. Avoid using this directly and rather [fetch a temporary access token out-of-band](#fetching-a-temporary-access-token)|
+
+## A note on Github App runner ##
+
+### Fetching a temporary access token ###
+
+By using the environment variable `APP_ID` and `APP_PRIVATE_KEY`, it is possible
+to use the container to fetch a temporary access token for the GitHub app by running:
+
+```
+docker run \
+  -e APP_ID="12345" \
+  -e APP_PRIVATE_KEY="$(</path/to/privatekey.pem)" \
+  --entrypoint /app_token.sh \
+  myoung34/github-runner:latest
+```
+
+
+When running a runner using a GitHub app to authenticate, both `APP_ID` and `APP_PRIVATE_KEY` needs to be provided.
+Under the hood, those credentials will be used to fetch a temporary access token.
+
+It is possible to pass them directly to the docker environment and have the container
+do all the magic with a command similar to:
+
+```
+docker run -d --restart always --name github-runner \
+  -e REPO_URL="https://github.com/myoung34/repo" \
+  -e RUNNER_NAME="foo-runner" \
+  -e RUNNER_WORKDIR="/tmp/github-runner-your-repo" \
+  -e RUNNER_GROUP="my-group" \
+  -e APP_ID="12345" \
+  -e APP_PRIVATE_KEY="$(</path/to/privatekey.pem)" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/github-runner-your-repo:/tmp/github-runner-your-repo \
+  myoung34/github-runner:latest
+```
+
+but this would make the private key possibly accessible from within the container,
+opening for possible exfiltration
+
+Instead you can generate an `ACCESS_TOKEN` out-of-band and pass this to the
+runner container as in:
+
+```
+docker run -d --restart always --name github-runner \
+  -e REPO_URL="https://github.com/myoung34/repo" \
+  -e RUNNER_NAME="foo-runner" \
+  -e RUNNER_WORKDIR="/tmp/github-runner-your-repo" \
+  -e RUNNER_GROUP="my-group" \
+  -e ACCESS_TOKEN="$(docker run \
+    -e APP_ID="12345" \
+    -e APP_PRIVATE_KEY="$(</path/to/privatekey.pem)" \
+    --entrypoint /app_token.sh \
+    myoung34/github-runner:latest)" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/github-runner-your-repo:/tmp/github-runner-your-repo \
+  myoung34/github-runner:latest
+```

--- a/app_token.sh
+++ b/app_token.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Request an ACCESS_TOKEN to be used by a GitHub APP
+# Environment variable that need to be set up:
+# * APP_ID, the GitHub's app ID
+# * APP_PRIVATE_KEY, the content of GitHub app's private key in PEM format.
+#
+# https://github.com/orgs/community/discussions/24743#discussioncomment-3245300
+#
+
+set -o pipefail
+
+_GITHUB_HOST=${GITHUB_HOST:="github.com"}
+
+# If URL is not github.com then use the enterprise api endpoint
+if [[ ${GITHUB_HOST} = "github.com" ]]; then
+  URI="https://api.${_GITHUB_HOST}"
+else
+  URI="https://${_GITHUB_HOST}/api/v3"
+fi
+
+API_VERSION=v3
+API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
+CONTENT_LENGTH_HEADER="Content-Length: 0"
+APP_INSTALLATIONS_URI="${URI}/app/installations"
+
+
+# JWT parameters based off
+# https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app
+#
+# JWT token issuance and expiration parameters
+JWT_IAT_DRIFT=60
+JWT_EXP_DELTA=600
+
+JWT_JOSE_HEADER='{
+    "alg": "RS256",
+    "typ": "JWT"
+}'
+
+
+build_jwt_payload() {
+    now=$(date +%s)
+    iat=$((now - JWT_IAT_DRIFT))
+    jq -c \
+        --arg iat_str "${iat}" \
+        --arg exp_delta_str "${JWT_EXP_DELTA}" \
+        --arg app_id_str "${APP_ID}" \
+    '
+        ($iat_str | tonumber) as $iat
+        | ($exp_delta_str | tonumber) as $exp_delta
+        | ($app_id_str | tonumber) as $app_id
+        | .iat = $iat
+        | .exp = ($iat + $exp_delta)
+        | .iss = $app_id
+    ' <<< "{}" | tr -d '\n'
+}
+
+base64url() {
+    base64 | tr '+/' '-_' | tr -d '=\n'
+}
+
+rs256_sign() {
+    openssl dgst -binary -sha256 -sign <(echo "$1")
+}
+
+request_access_token() {
+    jwt_payload=$(build_jwt_payload)
+    encoded_jwt_parts=$(base64url <<<"${JWT_JOSE_HEADER}").$(base64url <<<"${jwt_payload}")
+    encoded_mac=$(echo -n "$encoded_jwt_parts" | rs256_sign "${APP_PRIVATE_KEY}" | base64url)
+    generated_jwt="${encoded_jwt_parts}.${encoded_mac}"
+
+    auth_header="Authorization: Bearer ${generated_jwt}"
+
+    app_installations_response=$(curl -sX GET \
+        -H "${auth_header}" \
+        -H "${API_HEADER}" \
+        ${APP_INSTALLATIONS_URI} \
+    )
+    access_token_url=$(echo "$app_installations_response" | jq --raw-output '.[] | select (.app_id  == '"${APP_ID}"') .access_tokens_url')
+    curl -sX POST \
+        -H "${CONTENT_LENGTH_HEADER}" \
+        -H "${auth_header}" \
+        -H "${API_HEADER}" \
+        "${access_token_url}" | \
+        jq --raw-output .token
+}
+
+request_access_token

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,8 @@ export PATH=$PATH:/actions-runner
 # any command that needs them.  This may help prevent leaks.
 export -n ACCESS_TOKEN
 export -n RUNNER_TOKEN
+export -n APP_ID
+export -n APP_PRIVATE_KEY
 
 deregister_runner() {
   echo "Caught SIGTERM. Deregistering runner"
@@ -62,6 +64,11 @@ esac
 
 configure_runner() {
   ARGS=()
+  if [[ -n "${APP_ID}" ]] && [[ -n "${APP_PRIVATE_KEY}" ]]; then
+    echo "Obtaining access token for app_id ${APP_ID}"
+    ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY}" bash /app_token.sh)
+  fi
+
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     echo "Obtaining the token of the runner"
     _TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,8 +65,15 @@ esac
 configure_runner() {
   ARGS=()
   if [[ -n "${APP_ID}" ]] && [[ -n "${APP_PRIVATE_KEY}" ]]; then
+    if [[ -n "${ACCESS_TOKEN}" ]] || [[ -n "${RUNNER_TOKEN}" ]]; then
+      echo "ERROR: ACCESS_TOKEN or RUNNER_TOKEN provided but are mutually exclusive with APP_ID and APP_PRIVATE_KEY." >&2
+      exit 1
+    fi
     echo "Obtaining access token for app_id ${APP_ID}"
     ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY}" bash /app_token.sh)
+  elif [[ -n "${APP_ID}" ]] || [[ -n "${APP_PRIVATE_KEY}" ]]; then
+    echo "ERROR: Both APP_ID and APP_PRIVATE_KEY must be specified." >&2
+    exit 1
   fi
 
   if [[ -n "${ACCESS_TOKEN}" ]]; then


### PR DESCRIPTION
This changes allow to use a Github App to authenticate the runner.

A new script `app_token.sh` was added to fetch a temporary access token using the GitHub app's APP_ID and APP_PRIVATE_KEY.

The script can be called independently in order to generate an access_token out of band and use it in place of `ACCESS_TOKEN` (preferred method), but entrypoint.sh can also handle the presence of those env variables and fetch and set `ACCESS_TOKEN`.

The README is updated and provides warnings about the security implications.
Fixes #74