### PR TITLE
Add clang and libclang1 to base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -18,6 +18,8 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${GIT_CORE_PPA_KEY} \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
+    clang \
+    libclang1 \
     gnupg \
     lsb-release \
     curl \


### PR DESCRIPTION
This is needed for several language's libraries, I don't think it makes any harm and it's useful to a bunch of people, including me 😛 

I was wondering if you'd include it in your base image, otherwise I'll have to work with a fork 😄 

Thanks in advance.