### PR TITLE
Change recursive chown to flat chown for tools directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,7 +153,9 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
 else
   if [[ $(id -u) -eq 0 ]]; then
     [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && /usr/bin/chown -R runner "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
-    /usr/bin/chown -R runner "${_RUNNER_WORKDIR}" /opt/hostedtoolcache/ /actions-runner
+    /usr/bin/chown -R runner "${_RUNNER_WORKDIR}" /actions-runner
+    # The toolcache is not recursively chowned to avoid recursing over prepulated tooling in derived docker images
+    /usr/bin/chown runner /opt/hostedtoolcache/
     /usr/sbin/gosu runner "$@"
   else
     "$@"


### PR DESCRIPTION
If the tools cache is already populated with tooling in a derived docker image, performing a recursive chown significantly slows down ephemeral runner startup. The folder is created during image build and should hence be empty for a fresh runner. Consequently, removing the recursive operation should not affect the runner. See also issue #267.