### PR TITLE
Added using docker hostname instead manual generated random

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | --- | --- |
 | `RUN_AS_ROOT` | Boolean to run as root. If `true`: will run as root. If `True` and the user is overridden it will error. If any other value it will run as the `runner` user and allow an optional override. Default is `true` |
 | `RUNNER_NAME` | The name of the runner to use. Supercedes (overrides) `RUNNER_NAME_PREFIX` |
-| `RUNNER_NAME_PREFIX` | A prefix for a randomly generated name (followed by a random 13 digit string). You must not also provide `RUNNER_NAME`. Defaults to `github-runner` |
+| `RUNNER_NAME_PREFIX` | A prefix for runner name (followed by docker container id). You must not also provide `RUNNER_NAME`. Defaults to `github-runner`                                                                                                                                                              |
 | `ACCESS_TOKEN` | A [github PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to use to generate `RUNNER_TOKEN` dynamically at container start. Not using this requires a valid `RUNNER_TOKEN` |
 | `APP_ID` | The github application ID. Must be paired with `APP_PRIVATE_KEY` and should not be used with `ACCESS_TOKEN` or `RUNNER_TOKEN` |
 | `APP_PRIVATE_KEY` | The github application private key. Must be paired with `APP_ID` and should not be used with `ACCESS_TOKEN` or `RUNNER_TOKEN` |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,8 +23,8 @@ deregister_runner() {
 
 _DISABLE_AUTOMATIC_DEREGISTRATION=${DISABLE_AUTOMATIC_DEREGISTRATION:-false}
 
-_RUNNER_NAME=${RUNNER_NAME:-${RUNNER_NAME_PREFIX:-github-runner}-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')}
-_RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work}
+_RUNNER_NAME=${RUNNER_NAME:-${RUNNER_NAME_PREFIX:-github-runner}-$(cat /etc/hostname)}
+_RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work-${_RUNNER_NAME}}
 _LABELS=${LABELS:-default}
 _RUNNER_GROUP=${RUNNER_GROUP:-Default}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}


### PR DESCRIPTION
Hi! 
To be able to use docker's `--scale` option in a large number of containers while debugging particular instances I found it way more convenient to use the container name to reflect the name in the GitHub repository's admin instead of randomly generated IDs. 
Also using the host machine volume directory is better with the docker container id name. 

`cat /etc/hostname` - will output docker generated id which is easily visible in `docker ps -a` list.
 `_RUNNER_NAME` as the work dir name is convenient when you need to visit the runner directory without having to navigate internal docker volumes.

Thank you for your effort.