### PR TITLE
Make default workdir a subfolder under /_work

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ if [[ ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
   fi
 fi
 
-_RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work-${_RUNNER_NAME}}
+_RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work/${_RUNNER_NAME}}
 _LABELS=${LABELS:-default}
 _RUNNER_GROUP=${RUNNER_GROUP:-Default}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}


### PR DESCRIPTION
Hi @myoung34,

first of all, thanks a lot for this great project!

I have currently the problem, that I can not share files between "native" GitHub actions, which run inside a container based on your image and other actions wich run in their own Docker containers. 

The problem is, that there is no common/shared workdir. Currently the default workdir might be `/_work-oERTjrGWXtKcd` and in another worker `/_work-jHahu2ueAudhe`, etc. 

This PR makes the default workdir a sub directory under `/_work/`, for example `/_work/oERTjrGWXtKcd`.
This way, you can make `/_work/` a volume for all runner containers and share files between actions.

Best
Fabian