### PR TITLE
add whitespace around gh version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN mkdir -p /opt/hostedtoolcache
 
 ARG GH_RUNNER_VERSION="2.303.0"
 
-
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ LABEL maintainer="myoung34@my.apsu.edu"
 ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 RUN mkdir -p /opt/hostedtoolcache
 
+
+# GH_RUNNER_VERSION
 ARG GH_RUNNER_VERSION="2.303.0"
+
+
+
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN mkdir -p /opt/hostedtoolcache
 ARG GH_RUNNER_VERSION="2.303.0"
 
 
-
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ LABEL maintainer="myoung34@my.apsu.edu"
 ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 RUN mkdir -p /opt/hostedtoolcache
 
-# GH_RUNNER_VERSION
 ARG GH_RUNNER_VERSION="2.303.0"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ LABEL maintainer="myoung34@my.apsu.edu"
 ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 RUN mkdir -p /opt/hostedtoolcache
 
-
 # GH_RUNNER_VERSION
 ARG GH_RUNNER_VERSION="2.303.0"
 


### PR DESCRIPTION
This PR adds whitespace around the github version number in the Dockerfile, so a patch to the Dockerfile stays the same, even if the github version number changes. Closes #274