### PR TITLE
Update Docker Compose to v2

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,7 +4,6 @@ LABEL maintainer="myoung34@my.apsu.edu"
 ARG DUMB_INIT_VERSION="1.2.2"
 ARG GIT_CORE_PPA_KEY="A1715D88E1DF1F24"
 
-ENV DOCKER_COMPOSE_VERSION="1.27.4"
 ENV GIT_LFS_VERSION="3.2.0"
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
@@ -63,8 +62,8 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && version=$(lsb_release -cs | sed 's/bookworm\|n\/a/bullseye/g') \
   && ( echo "deb [arch=${DPKG_ARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${distro} ${version} stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null ) \
   && apt-get update \
-  && apt-get install -y docker-ce docker-ce-cli docker-buildx-plugin containerd.io --no-install-recommends --allow-unauthenticated \
-  && ( [[ $(lscpu -J | jq -r '.lscpu[] | select(.field == "Vendor ID:") | .data') == "ARM" ]] && echo "Not installing docker-compose. See https://github.com/docker/compose/issues/6831" || ( curl -sL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose ) ) \
+  && apt-get install -y docker-ce docker-ce-cli docker-buildx-plugin containerd.io docker-compose-plugin --no-install-recommends --allow-unauthenticated \
+  && echo "docker compose --compatibility \"\$@\"" > /bin/docker-compose && chmod +x /bin/docker-compose \
   && ( [[ "${LSB_RELEASE_CODENAME}" == "focal" ]] && ( echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && curl -L "https://build.opensuse.org/projects/devel:kubic/public_key" | apt-key add -; echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && curl -L "https://build.opensuse.org/projects/devel:kubic/public_key" | apt-key add - && apt-get update) || : ) \
   && ( [[ "${LSB_RELEASE_CODENAME}" == "focal" || "${LSB_RELEASE_CODENAME}" == "jammy" || "${LSB_RELEASE_CODENAME}" == "sid" || "${LSB_RELEASE_CODENAME}" == "bullseye" ]] && apt-get install -y --no-install-recommends podman buildah skopeo || : ) \
   && ( [[ "${LSB_RELEASE_CODENAME}" == "jammy" ]] && echo "Ubuntu Jammy is marked as beta. Please see https://github.com/actions/virtual-environments/issues/5490" || : ) \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -63,7 +63,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && ( echo "deb [arch=${DPKG_ARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${distro} ${version} stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null ) \
   && apt-get update \
   && apt-get install -y docker-ce docker-ce-cli docker-buildx-plugin containerd.io docker-compose-plugin --no-install-recommends --allow-unauthenticated \
-  && echo "docker compose --compatibility \"\$@\"" > /bin/docker-compose && chmod +x /bin/docker-compose \
+  && echo -e '#!/usr/bin/sh\ndocker compose --compatibility "$@"' > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose \
   && ( [[ "${LSB_RELEASE_CODENAME}" == "focal" ]] && ( echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && curl -L "https://build.opensuse.org/projects/devel:kubic/public_key" | apt-key add -; echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && curl -L "https://build.opensuse.org/projects/devel:kubic/public_key" | apt-key add - && apt-get update) || : ) \
   && ( [[ "${LSB_RELEASE_CODENAME}" == "focal" || "${LSB_RELEASE_CODENAME}" == "jammy" || "${LSB_RELEASE_CODENAME}" == "sid" || "${LSB_RELEASE_CODENAME}" == "bullseye" ]] && apt-get install -y --no-install-recommends podman buildah skopeo || : ) \
   && ( [[ "${LSB_RELEASE_CODENAME}" == "jammy" ]] && echo "Ubuntu Jammy is marked as beta. Please see https://github.com/actions/virtual-environments/issues/5490" || : ) \


### PR DESCRIPTION
This PR updates docker compose to v2 (see differences between v1 and v2 [here](https://stackoverflow.com/a/66516826)). Compose is now installed via the docker compose plugin rather than installing the docker-compose executable as seen [here](https://docs.docker.com/compose/install/linux/). This PR also indirectly fixes #222.

In addition, I added a compatibility file located at `/usr/local/bin/docker-compose` which will allow executing docker compose commands with `docker-compose` instead of the new syntax `docker compose` to prevent breaking anyone's current process.

This has been successfully built on a MacBook (ARM64) as well as a CentOS 9 server (AMD64). The following command should print out the docker compose version after building the base image: `docker run --rm -it myoung34/github-runner-base:latest docker compose version`

Please let me know if there is anything else I can help test or fix!