### PR TITLE
remove warning about compose on ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,6 @@ Also, some GitHub Actions Workflow features, like [Job Services](https://docs.gi
 
 Currently runners [do not support containerd](https://github.com/actions/runner/issues/1265)
 
-### Docker-Compose on ARM ###
-
-Please note `docker-compose` does not currently work on ARM ([see issue](https://github.com/docker/compose/issues/6831)) so it is not installed on ARM based builds here.
-A workaround exists, please see [here](https://github.com/myoung34/docker-github-actions-runner/issues/72#issuecomment-804723656)
-
 ## Docker Artifacts ##
 
 | Container Base | Supported Architectures | Tag Regex | Docker Tags | Description | Notes |


### PR DESCRIPTION
First off, amazing stuff. Works like a charm on my Raspberry Pi 4gb. I just created a simple compose yml and pasted in your example including the token from my repo's runner settings. It all just works.

Check out this action which actually ran using your image on my Pi. https://github.com/viseshrp/website/actions/runs/4846104297/jobs/8635430719

So, I think the warning about compose is no longer valid.

Basically fixes #290 