### PR TITLE
feat: add the libpq-dev into dockerfile base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -45,6 +45,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
     dumb-init \
     nodejs \
     rsync \
+    libpq-dev \
     gosu \
   && DPKG_ARCH="$(dpkg --print-architecture)" \
   && LSB_RELEASE_CODENAME="$(lsb_release --codename | cut -f2)" \


### PR DESCRIPTION
the github runner is support libpq-dev, I think it's better for this one also support this

Referrence
https://github.com/actions/runner-images/issues/12