### PR TITLE
Fix path to chown for debian and ubuntu delta

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -10,7 +10,7 @@ ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
-# hadolint ignore=SC2086,DL3015,DL3008,DL3013
+# hadolint ignore=SC2086,DL3015,DL3008,DL3013,SC2015
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && apt-get update \
   && apt-get install -y --no-install-recommends gnupg \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -185,10 +185,10 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
   fi
 else
   if [[ $(id -u) -eq 0 ]]; then
-    [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && /usr/bin/chown -R runner "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
-    /usr/bin/chown -R runner "${_RUNNER_WORKDIR}" /actions-runner
+    [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && chown -R runner "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
+    chown -R runner "${_RUNNER_WORKDIR}" /actions-runner
     # The toolcache is not recursively chowned to avoid recursing over prepulated tooling in derived docker images
-    /usr/bin/chown runner /opt/hostedtoolcache/
+    chown runner /opt/hostedtoolcache/
     /usr/sbin/gosu runner "$@"
   else
     "$@"


### PR DESCRIPTION
Resolves https://github.com/myoung34/docker-github-actions-runner/issues/304

```
➜ docker run -it ubuntu:focal which -a chown
/usr/bin/chown
/bin/chown
➜ docker run -it debian:buster which -a chown
/bin/chown
➜ docker run -it debian:bullseye which -a chown
/bin/chown
```

This change will resolve it since PATH in all those covers `/usr/bin` and `/bin`