### PR TITLE
Use node LTS when building runner image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,8 +13,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=SC2086,DL3015,DL3008,DL3013,SC2015
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && apt-get update \
-  && apt-get install -y --no-install-recommends gnupg \
+  && apt-get install -y --no-install-recommends gnupg curl \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${GIT_CORE_PPA_KEY} \
+  && curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash - \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
     gnupg \


### PR DESCRIPTION
Current images use an old version of nodejs (version 10). 
Running some workflows on these images fail because it assumes that node version is at least 16 ([GraphQL for example](https://github.com/unknorg/workflow-preprocessor/actions/runs/5346240353/jobs/9692968387)).

This PR builds the runners using the LTS version of nodejs.