### PR TITLE
Install python3-venv

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -45,7 +45,8 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
     locales \
     python3-pip \
     python3-setuptools \
-    python3 \
+    python3-venv \
+    python3 \    
     dumb-init \
     nodejs \
     rsync \


### PR DESCRIPTION
The proposed change installs python3-venv, on top of python3, which is a requirement for cfn-linter (and probably others?)

Without it, the error shows:
```
Run scottbrenner/cfn-lint-action@v2
##[add-matcher]/_work/yopdev-cicd-runner--aIk16GWGgIQZE/_actions/scottbrenner/cfn-lint-action/v2/.github/cfn-lint.json
##[debug]Added matchers: 'cfn-lint', 'cfn-lint-warnings'. Problem matchers scan action output for known warning or error strings and report these inline.
/usr/bin/python3 --version
Python 3.8.10
/usr/bin/python3 -m venv /tmp/setup-cfn-lint-QLO4Gb/.venv
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt install python3.8-venv

You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.
```