### PR TITLE
feat: added PowerShell/PowerShell

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -80,6 +80,10 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && YQ_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r '.tag_name' | sed 's/^v//g') \
   && YQ_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/mikefarah/yq/releases/latest | jq ".assets[] | select(.name == \"yq_linux_${DPKG_ARCH}.tar.gz\")" | jq -r '.browser_download_url') \
   && ( curl -s ${YQ_DOWNLOAD_URL} -L -o /tmp/yq.tar.gz && tar -xzf /tmp/yq.tar.gz -C /tmp && mv /tmp/yq_linux_${DPKG_ARCH} /usr/local/bin/yq) \
+  && PWSH_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r '.tag_name' | sed 's/^v//g') \
+  && PWSH_DOUNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r ".assets[] | select(.name == \"powershell-${PWSH_VERSION}-linux-${DPKG_ARCH//amd64/x64}.tar.gz\") | .browser_download_url") \
+  && curl -L -o /tmp/powershell.tar.gz $PWSH_DOUNLOAD_URL && sudo mkdir -p /opt/powershell && sudo tar zxf /tmp/powershell.tar.gz -C /opt/powershell && rm -f /tmp/powershell.tar.gz \
+  && sudo chmod +x /opt/powershell/pwsh && sudo ln -s /opt/powershell/pwsh /usr/bin/pwsh \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /tmp/* \
   && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -82,7 +82,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
   && ( curl -s ${YQ_DOWNLOAD_URL} -L -o /tmp/yq.tar.gz && tar -xzf /tmp/yq.tar.gz -C /tmp && mv /tmp/yq_linux_${DPKG_ARCH} /usr/local/bin/yq) \
   && PWSH_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r '.tag_name' | sed 's/^v//g') \
   && PWSH_DOUNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r ".assets[] | select(.name == \"powershell-${PWSH_VERSION}-linux-${DPKG_ARCH//amd64/x64}.tar.gz\") | .browser_download_url") \
-  && curl -L -o /tmp/powershell.tar.gz $PWSH_DOUNLOAD_URL && sudo mkdir -p /opt/powershell && sudo tar zxf /tmp/powershell.tar.gz -C /opt/powershell && rm -f /tmp/powershell.tar.gz \
+  && curl -L -o /tmp/powershell.tar.gz $PWSH_DOUNLOAD_URL && sudo mkdir -p /opt/powershell && sudo tar zxf /tmp/powershell.tar.gz -C /opt/powershell \
   && sudo chmod +x /opt/powershell/pwsh && sudo ln -s /opt/powershell/pwsh /usr/bin/pwsh \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /tmp/* \


### PR DESCRIPTION
Hello @myoung34

I would like to use powershell on github self-hosted runner.
Therefor, I have added [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell) on the base docker image.


I have been cheked on ubuntu 22.04 arm64 and amd64.

ubuntu 22.04 amd64
```
$ dpkg --print-architecture
amd64
$ docker -v
Docker version 26.1.0, build 9714adc
$ docker build ./ -f Dockerfile.base -t docker-github-actions-runner:powershell-test
$ docker run --rm -it docker-github-actions-runner:powershell-test bash
root@42dcb84d1d19:/# pwsh -Version
PowerShell 7.4.2
```

ubuntu 22.04 arm64
```
$ dpkg --print-architecture
arm64
$ docker -v
Docker version 26.1.0, build 9714adc
$ docker build ./ -f Dockerfile.base -t docker-github-actions-runner:powershell-test
$ docker run --rm -it docker-github-actions-runner:powershell-test bash
root@f7a7f0ae31fe:/# pwsh -Version                                                           
PowerShell 7.4.2
```


Could you please check if everything is okay?