### PR TITLE
feat: Prevent exposure of configuration environment variables to runner workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `NO_DEFAULT_LABELS` | Optional environment variable to disable adding the default self-hosted, platform, and architecture labels to the runner. Any value is considered truthy and will disable them. |
 | `DEBUG_ONLY` | Optional boolean to print debug output but not run any actual registration or runner commands. Used in CI and testing. Default: false |
 | `DEBUG_OUTPUT` | Optional boolean to print additional debug output. Default: false |
-
+| `UNSET_CONFIG_VARS` | Optional flag to unset all configuration environment variables after runner setup but before starting the runner. This prevents these variables from leaking into the workflow environment. Set to 'true' to enable. Defaults to 'false' for backward compatibility. |
 
 ## Tests ##
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,6 +57,7 @@ _RUNNER_GROUP=${RUNNER_GROUP:-Default}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 _RUN_AS_ROOT=${RUN_AS_ROOT:="true"}
 _START_DOCKER_SERVICE=${START_DOCKER_SERVICE:="false"}
+_UNSET_CONFIG_VARS=${UNSET_CONFIG_VARS:="false"}
 
 # ensure backwards compatibility
 if [[ -z ${RUNNER_SCOPE} ]]; then
@@ -151,6 +152,33 @@ configure_runner() {
 
 }
 
+unset_config_vars() {
+  echo "Unsetting configuration environment variables"
+  unset RUN_AS_ROOT
+  unset RUNNER_NAME
+  unset RUNNER_NAME_PREFIX
+  unset RANDOM_RUNNER_SUFFIX
+  unset ACCESS_TOKEN
+  unset APP_ID
+  unset APP_PRIVATE_KEY
+  unset APP_LOGIN
+  unset RUNNER_SCOPE
+  unset ORG_NAME
+  unset ENTERPRISE_NAME
+  unset LABELS
+  unset REPO_URL
+  unset RUNNER_TOKEN
+  unset RUNNER_WORKDIR
+  unset RUNNER_GROUP
+  unset GITHUB_HOST
+  unset DISABLE_AUTOMATIC_DEREGISTRATION
+  unset CONFIGURED_ACTIONS_RUNNER_FILES_DIR
+  unset EPHEMERAL
+  unset DISABLE_AUTO_UPDATE
+  unset START_DOCKER_SERVICE
+  unset NO_DEFAULT_LABELS
+  unset UNSET_CONFIG_VARS
+}
 
 # Opt into runner reusage because a value was given
 if [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
@@ -202,6 +230,11 @@ if [[ ${_START_DOCKER_SERVICE} == "true" ]]; then
   else
     ${_PREFIX} service docker start
   fi
+fi
+
+# Unset configuration environment variables if the flag is set
+if [[ ${_UNSET_CONFIG_VARS} == "true" ]]; then
+  unset_config_vars
 fi
 
 # Container's command (CMD) execution as runner user

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,6 +58,7 @@ _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 _RUN_AS_ROOT=${RUN_AS_ROOT:="true"}
 _START_DOCKER_SERVICE=${START_DOCKER_SERVICE:="false"}
 _UNSET_CONFIG_VARS=${UNSET_CONFIG_VARS:="false"}
+_CONFIGURED_ACTIONS_RUNNER_FILES_DIR=${CONFIGURED_ACTIONS_RUNNER_FILES_DIR:-""}
 
 # ensure backwards compatibility
 if [[ -z ${RUNNER_SCOPE} ]]; then
@@ -181,13 +182,13 @@ unset_config_vars() {
 }
 
 # Opt into runner reusage because a value was given
-if [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
+if [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
   echo "Runner reusage is enabled"
 
   # directory exists, copy the data
-  if [[ -d "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
+  if [[ -d "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
     echo "Copying previous data"
-    cp -p -r "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/." "/actions-runner"
+    cp -p -r "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/." "/actions-runner"
   fi
 
   if [ -f "/actions-runner/.runner" ]; then
@@ -205,10 +206,10 @@ else
   fi
 fi
 
-if [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
-  echo "Reusage is enabled. Storing data to ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
+if [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
+  echo "Reusage is enabled. Storing data to ${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
   # Quoting (even with double-quotes) the regexp brokes the copying
-  cp -p -r "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
+  cp -p -r "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
 fi
 
 
@@ -268,7 +269,7 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
   fi
 else
   if [[ $(id -u) -eq 0 ]]; then
-    [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && chown -R runner "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
+    [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && chown -R runner "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
     chown -R runner "${_RUNNER_WORKDIR}" /actions-runner
     # The toolcache is not recursively chowned to avoid recursing over prepulated tooling in derived docker images
     chown runner /opt/hostedtoolcache/


### PR DESCRIPTION
closes #383 

1. Added a new environment variable flag `UNSET_CONFIG_VARS`. When set to `true`, it triggers the removal of all configuration environment variables after runner setup.
2. Refactored the usage of `CONFIGURED_ACTIONS_RUNNER_FILES_DIR` to use a local variable. This ensures proper functionality after unsetting environment variables.

## Testing Procedure

To verify the changes, follow these steps:

1. Build the Docker image:
   ```bash
   docker build -t yamoyamoto/github-runner .
   ```

2. Set up required environment variables:
   ```bash
   export REPO_URL='https://github.com/yamoyamoto/repo' 
   export RUNNER_NAME=runner-test
   export RUNNER_TOKEN=***** # Replace with actual token
   ```

3. Run the container without the new flag:
   ```bash
   docker run --rm --name github-runner \
     -e REPO_URL="${REPO_URL}" \
     -e RUNNER_NAME="${RUNNER_NAME}" \
     -e RUNNER_TOKEN="${RUNNER_TOKEN}" \
     yamoyamoto/github-runner
   ```

4. Run the container with the new flag enabled:
   ```bash
   docker run --rm --name github-runner \
     -e REPO_URL="${REPO_URL}" \
     -e RUNNER_NAME="${RUNNER_NAME}" \
     -e RUNNER_TOKEN="${RUNNER_TOKEN}" \
     -e UNSET_CONFIG_VARS="true" \
     yamoyamoto/github-runner
   ```

## Verification Results

To confirm the effectiveness of the changes, we used [hmarr/debug-action](https://github.com/hmarr/debug-action) to dump and inspect the environment variables in both scenarios.

### With UNSET_CONFIG_VARS=true

- The `REPO_URL` environment variable has been unset

![image](https://github.com/user-attachments/assets/0720ca98-4a60-4ce7-975d-dc8e4227580b)

### With default behavior (UNSET_CONFIG_VARS=false)

- The REPO_URL environment variable has not been unset

![image](https://github.com/user-attachments/assets/c2208085-3ae7-4acd-83cd-f85d9e166434)
