### PR TITLE
Refactored to a set of install scripts to avoid adding further complexity to the base Dockerfile and make it easier to disable tools

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,94 +2,14 @@ FROM ubuntu:focal
 LABEL maintainer="myoung34@my.apsu.edu"
 
 ARG DUMB_INIT_VERSION="1.2.2"
-ARG GIT_CORE_PPA_KEY="A1715D88E1DF1F24"
-
 # TODO: remove git PPA and skopeo customizations for focal when focal hits EOL
 ENV GIT_LFS_VERSION="3.2.0"
+
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
-# hadolint ignore=SC2086,DL3015,DL3008,DL3013,SC2015
-RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends gnupg \
-  && ( \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${GIT_CORE_PPA_KEY} \
-      || apt-key adv --keyserver pgp.mit.edu --recv-keys ${GIT_CORE_PPA_KEY} \
-      || apt-key adv --keyserver keyserver.pgp.com --recv-keys ${GIT_CORE_PPA_KEY} \
-  ) \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-    gnupg \
-    lsb-release \
-    curl \
-    tar \
-    unzip \
-    zip \
-    apt-transport-https \
-    ca-certificates \
-    sudo \
-    gpg-agent \
-    software-properties-common \
-    build-essential \
-    zlib1g-dev \
-    zstd \
-    gettext \
-    libcurl4-openssl-dev \
-    inetutils-ping \
-    jq \
-    wget \
-    dirmngr \
-    openssh-client \
-    locales \
-    python3-pip \
-    python3-setuptools \
-    python3-venv \
-    python3 \
-    dumb-init \
-    nodejs \
-    rsync \
-    libpq-dev \
-    gosu \
-    pkg-config \
-  && DPKG_ARCH="$(dpkg --print-architecture)" \
-  && LSB_RELEASE_CODENAME="$(lsb_release --codename | cut -f2)" \
-  && sed -e 's/Defaults.*env_reset/Defaults env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers \
-  && ( [[ "${LSB_RELEASE_CODENAME}" == "focal" ]] && (echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu focal main>/etc/apt/sources.list.d/git-core.list ) || : ) \
-  && apt-get update \
-  && ( apt-get install -y --no-install-recommends git || apt-get install -t stable -y --no-install-recommends git ) \
-  && ( [[ $(apt-cache search -n liblttng-ust0 | awk '{print $1}') == "liblttng-ust0" ]] && apt-get install -y --no-install-recommends liblttng-ust0 || : ) \
-  && ( [[ $(apt-cache search -n liblttng-ust1 | awk '{print $1}') == "liblttng-ust1" ]] && apt-get install -y --no-install-recommends liblttng-ust1 || : ) \
-  && ( ( curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && unzip awscliv2.zip -d /tmp/ && /tmp/aws/install && rm awscliv2.zip) || pip3 install --no-cache-dir awscli ) \
-  && ( curl -s "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${DPKG_ARCH}-v${GIT_LFS_VERSION}.tar.gz" -L -o /tmp/lfs.tar.gz && tar -xzf /tmp/lfs.tar.gz -C /tmp && /tmp/git-lfs-${GIT_LFS_VERSION}/install.sh && rm -rf /tmp/lfs.tar.gz  /tmp/git-lfs-${GIT_LFS_VERSION}) \
-  && distro=$(lsb_release -is | awk '{print tolower($0)}') \
-  && mkdir -p /etc/apt/keyrings \
-  && ( curl -fsSL https://download.docker.com/linux/${distro}/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg ) \
-  && version=$(lsb_release -cs | sed 's/trixie\|n\/a/bookworm/g') \
-  && ( echo "deb [arch=${DPKG_ARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${distro} ${version} stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null ) \
-  && apt-get update \
-  && apt-get install -y docker-ce docker-ce-cli docker-buildx-plugin containerd.io docker-compose-plugin --no-install-recommends --allow-unauthenticated \
-  && echo -e '#!/bin/sh\ndocker compose --compatibility "$@"' > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose \
-  && ( [[ "${LSB_RELEASE_CODENAME}" == "focal" ]] && ( echo "available in 20.10 and higher" && echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && curl -L "https://build.opensuse.org/projects/devel:kubic/signing_keys/download?kind=gpg" | apt-key add - ) || : ) \
-  && apt-get update \
-  && ( apt-get install -y --no-install-recommends podman buildah skopeo || : ) \
-  && GH_CLI_VERSION=$(curl -sL -H "Accept: application/vnd.github+json"   https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name' | sed 's/^v//g') \
-  && GH_CLI_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json"   https://api.github.com/repos/cli/cli/releases/latest | jq ".assets[] | select(.name == \"gh_${GH_CLI_VERSION}_linux_${DPKG_ARCH}.deb\")" | jq -r '.browser_download_url') \
-  && curl -sSLo /tmp/ghcli.deb ${GH_CLI_DOWNLOAD_URL} && apt-get -y install /tmp/ghcli.deb && rm /tmp/ghcli.deb \
-  && YQ_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r '.tag_name' | sed 's/^v//g') \
-  && YQ_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/mikefarah/yq/releases/latest | jq ".assets[] | select(.name == \"yq_linux_${DPKG_ARCH}.tar.gz\")" | jq -r '.browser_download_url') \
-  && ( curl -s ${YQ_DOWNLOAD_URL} -L -o /tmp/yq.tar.gz && tar -xzf /tmp/yq.tar.gz -C /tmp && mv /tmp/yq_linux_${DPKG_ARCH} /usr/local/bin/yq) \
-  && PWSH_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r '.tag_name' | sed 's/^v//g') \
-  && PWSH_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" https://api.github.com/repos/PowerShell/PowerShell/releases/latest | jq -r ".assets[] | select(.name == \"powershell-${PWSH_VERSION}-linux-${DPKG_ARCH//amd64/x64}.tar.gz\") | .browser_download_url") \
-  && ( curl -L -o /tmp/powershell.tar.gz $PWSH_DOWNLOAD_URL && mkdir -p /opt/powershell && tar zxf /tmp/powershell.tar.gz -C /opt/powershell && chmod +x /opt/powershell/pwsh && ln -s /opt/powershell/pwsh /usr/bin/pwsh ) \
-  && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /tmp/* \
-  && sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker \
-  && groupadd -g 121 runner \
-  && useradd -mr -d /home/runner -u 1001 -g 121 runner \
-  && usermod -aG sudo runner \
-  && usermod -aG docker runner \
-  && echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
-  && ( [[ -f /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list ]] && rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list || : )
+
+COPY --chmod=700 build/ /tmp/build/
+RUN /tmp/build/install_base.sh

--- a/build/install_base.sh
+++ b/build/install_base.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function bootstrap_sources() {
+  apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gnupg
+}
+
+function install_tools_apt() {
+  apt-get install -y --no-install-recommends \
+    tar \
+    unzip \
+    zip \
+    apt-transport-https \
+    sudo \
+    gpg-agent \
+    software-properties-common \
+    jq \
+    dirmngr \
+    locales \
+    dumb-init \
+    gosu \
+    build-essential \
+    zlib1g-dev \
+    zstd \
+    gettext \
+    libcurl4-openssl-dev \
+    inetutils-ping \
+    wget \
+    openssh-client \
+    python3-pip \
+    python3-setuptools \
+    python3-venv \
+    python3 \
+    nodejs \
+    rsync \
+    libpq-dev \
+    pkg-config
+}
+
+function remove_caches() {
+  rm -rf /var/lib/apt/lists/*
+  rm -rf /tmp/*
+}
+
+function setup_sudoers() {
+  sed -e 's/Defaults.*env_reset/Defaults env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers
+  echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+}
+
+echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
+
+scripts_dir=$(dirname "$0")
+. "$scripts_dir/sources.sh"
+. "$scripts_dir/tools.sh"
+
+apt-get update
+bootstrap_sources
+configure_sources
+
+apt-get update
+install_tools_apt
+install_tools
+remove_sources
+remove_caches
+
+setup_sudoers
+groupadd -g 121 runner
+useradd -mr -d /home/runner -u 1001 -g 121 runner
+usermod -aG sudo runner
+usermod -aG docker runner

--- a/build/install_base.sh
+++ b/build/install_base.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
 function bootstrap_sources() {
@@ -54,8 +53,10 @@ function setup_sudoers() {
 echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 scripts_dir=$(dirname "$0")
-. "$scripts_dir/sources.sh"
-. "$scripts_dir/tools.sh"
+# shellcheck source=/dev/null
+source "$scripts_dir/sources.sh"
+# shellcheck source=/dev/null
+source "$scripts_dir/tools.sh"
 
 apt-get update
 bootstrap_sources

--- a/build/sources.sh
+++ b/build/sources.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function configure_git() {
+  source /etc/os-release
+
+  local GIT_CORE_PPA_KEY="A1715D88E1DF1F24"
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${GIT_CORE_PPA_KEY} \
+    || apt-key adv --keyserver pgp.mit.edu --recv-keys ${GIT_CORE_PPA_KEY} \
+    || apt-key adv --keyserver keyserver.pgp.com --recv-keys ${GIT_CORE_PPA_KEY}
+
+  ( [[ "${VERSION_CODENAME}" == "focal" ]] \
+   && (echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu focal main>/etc/apt/sources.list.d/git-core.list ) || : )
+}
+
+function configure_docker() {
+  source /etc/os-release
+
+  mkdir -p /etc/apt/keyrings
+  curl -fsSL "https://download.docker.com/linux/$ID/gpg" | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+  local version=$(echo "$VERSION_CODENAME" | sed 's/trixie\|n\/a/bookworm/g')
+  local DPKG_ARCH="$(dpkg --print-architecture)"
+  echo "deb [arch=${DPKG_ARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$ID ${version} stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null
+}
+
+function configure_container_tools() {
+  source /etc/os-release
+
+  ( [[ "${VERSION_CODENAME}" == "focal" ]] \
+    && ( echo "available in 20.10 and higher" \
+    && echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" \
+      | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list \
+    && curl -L "https://build.opensuse.org/projects/devel:kubic/signing_keys/download?kind=gpg" \
+      | apt-key add - ) || : )
+}
+
+function configure_sources() {
+  configure_git
+  configure_docker
+  configure_container_tools
+}
+
+function remove_sources() {
+  rm -f /etc/apt/sources.list.d/git-core.list
+  rm -f /etc/apt/sources.list.d/docker.list
+  rm -f /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+}

--- a/build/sources.sh
+++ b/build/sources.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 function configure_git() {
+  # shellcheck source=/dev/null
   source /etc/os-release
 
   local GIT_CORE_PPA_KEY="A1715D88E1DF1F24"
@@ -9,31 +10,36 @@ function configure_git() {
     || apt-key adv --keyserver pgp.mit.edu --recv-keys ${GIT_CORE_PPA_KEY} \
     || apt-key adv --keyserver keyserver.pgp.com --recv-keys ${GIT_CORE_PPA_KEY}
 
-  ( [[ "${VERSION_CODENAME}" == "focal" ]] \
-   && (echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu focal main>/etc/apt/sources.list.d/git-core.list ) || : )
+  if [[ "${VERSION_CODENAME}" == "focal" ]]; then
+    echo deb http://ppa.launchpad.net/git-core/ppa/ubuntu focal main>/etc/apt/sources.list.d/git-core.list
+  fi
 }
 
 function configure_docker() {
+  # shellcheck source=/dev/null
   source /etc/os-release
 
   mkdir -p /etc/apt/keyrings
   curl -fsSL "https://download.docker.com/linux/$ID/gpg" | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 
-  local version=$(echo "$VERSION_CODENAME" | sed 's/trixie\|n\/a/bookworm/g')
-  local DPKG_ARCH="$(dpkg --print-architecture)"
+  local version DPKG_ARCH
+  version=$(echo "$VERSION_CODENAME" | sed 's/trixie\|n\/a/bookworm/g')
+  DPKG_ARCH="$(dpkg --print-architecture)"
   echo "deb [arch=${DPKG_ARCH} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$ID ${version} stable" \
     | tee /etc/apt/sources.list.d/docker.list > /dev/null
 }
 
 function configure_container_tools() {
+  # shellcheck source=/dev/null
   source /etc/os-release
 
-  ( [[ "${VERSION_CODENAME}" == "focal" ]] \
-    && ( echo "available in 20.10 and higher" \
-    && echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" \
-      | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list \
-    && curl -L "https://build.opensuse.org/projects/devel:kubic/signing_keys/download?kind=gpg" \
-      | apt-key add - ) || : )
+  if [[ "${VERSION_CODENAME}" == "focal" ]]; then
+    echo "available in 20.10 and higher"
+    echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" \
+      | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    curl -L "https://build.opensuse.org/projects/devel:kubic/signing_keys/download?kind=gpg" \
+      | apt-key add -
+  fi
 }
 
 function configure_sources() {

--- a/build/tools.sh
+++ b/build/tools.sh
@@ -7,11 +7,13 @@ function install_git() {
 }
 
 function install_liblttng_ust() {
-  ( [[ $(apt-cache search -n liblttng-ust0 | awk '{print $1}') == "liblttng-ust0" ]] \
-    && apt-get install -y --no-install-recommends liblttng-ust0 || : )
+  if [[ $(apt-cache search -n liblttng-ust0 | awk '{print $1}') == "liblttng-ust0" ]]; then
+    apt-get install -y --no-install-recommends liblttng-ust0
+  fi
 
-  ( [[ $(apt-cache search -n liblttng-ust1 | awk '{print $1}') == "liblttng-ust1" ]] \
-    && apt-get install -y --no-install-recommends liblttng-ust1 || : )
+  if [[ $(apt-cache search -n liblttng-ust1 | awk '{print $1}') == "liblttng-ust1" ]]; then
+    apt-get install -y --no-install-recommends liblttng-ust1
+  fi
 }
 
 function install_awscli() {
@@ -24,12 +26,13 @@ function install_awscli() {
 }
 
 function install_gitlfs() {
-  local DPKG_ARCH="$(dpkg --print-architecture)"
+  local DPKG_ARCH
+  DPKG_ARCH="$(dpkg --print-architecture)"
 
   curl -s "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${DPKG_ARCH}-v${GIT_LFS_VERSION}.tar.gz" -L -o /tmp/lfs.tar.gz
   tar -xzf /tmp/lfs.tar.gz -C /tmp
-  /tmp/git-lfs-${GIT_LFS_VERSION}/install.sh
-  rm -rf /tmp/lfs.tar.gz /tmp/git-lfs-${GIT_LFS_VERSION}
+  "/tmp/git-lfs-${GIT_LFS_VERSION}/install.sh"
+  rm -rf /tmp/lfs.tar.gz "/tmp/git-lfs-${GIT_LFS_VERSION}"
 }
 
 function install_docker() {
@@ -46,7 +49,9 @@ function install_container_tools() {
 }
 
 function install_githubcli() {
-  local DPKG_ARCH="$(dpkg --print-architecture)"
+  local DPKG_ARCH GH_CLI_VERSION GH_CLI_DOWNLOAD_URL
+
+  DPKG_ARCH="$(dpkg --print-architecture)"
 
   GH_CLI_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" \
     https://api.github.com/repos/cli/cli/releases/latest \
@@ -63,32 +68,31 @@ function install_githubcli() {
 }
 
 function install_yq() {
-  local DPKG_ARCH="$(dpkg --print-architecture)"
+  local DPKG_ARCH YQ_DOWNLOAD_URL
 
-  local YQ_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" \
-    https://api.github.com/repos/mikefarah/yq/releases/latest \
-      | jq -r '.tag_name' \
-      | sed 's/^v//g')
+  DPKG_ARCH="$(dpkg --print-architecture)"
 
-  local YQ_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" \
+  YQ_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" \
     https://api.github.com/repos/mikefarah/yq/releases/latest \
       | jq ".assets[] | select(.name == \"yq_linux_${DPKG_ARCH}.tar.gz\")" \
       | jq -r '.browser_download_url')
 
   curl -s "${YQ_DOWNLOAD_URL}" -L -o /tmp/yq.tar.gz
   tar -xzf /tmp/yq.tar.gz -C /tmp
-  mv /tmp/yq_linux_${DPKG_ARCH} /usr/local/bin/yq
+  mv "/tmp/yq_linux_${DPKG_ARCH}" /usr/local/bin/yq
 }
 
 function install_powershell() {
-  local DPKG_ARCH="$(dpkg --print-architecture)"
+  local DPKG_ARCH PWSH_VERSION PWSH_DOWNLOAD_URL
 
-  local PWSH_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" \
+  DPKG_ARCH="$(dpkg --print-architecture)"
+
+  PWSH_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" \
     https://api.github.com/repos/PowerShell/PowerShell/releases/latest \
       | jq -r '.tag_name' \
       | sed 's/^v//g')
 
-  local PWSH_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" \
+  PWSH_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" \
     https://api.github.com/repos/PowerShell/PowerShell/releases/latest \
       | jq -r ".assets[] | select(.name == \"powershell-${PWSH_VERSION}-linux-${DPKG_ARCH//amd64/x64}.tar.gz\") | .browser_download_url")
 

--- a/build/tools.sh
+++ b/build/tools.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function install_git() {
+  ( apt-get install -y --no-install-recommends git \
+   || apt-get install -t stable -y --no-install-recommends git )
+}
+
+function install_liblttng_ust() {
+  ( [[ $(apt-cache search -n liblttng-ust0 | awk '{print $1}') == "liblttng-ust0" ]] \
+    && apt-get install -y --no-install-recommends liblttng-ust0 || : )
+
+  ( [[ $(apt-cache search -n liblttng-ust1 | awk '{print $1}') == "liblttng-ust1" ]] \
+    && apt-get install -y --no-install-recommends liblttng-ust1 || : )
+}
+
+function install_awscli() {
+  ( curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" \
+    && unzip -q awscliv2.zip -d /tmp/ \
+    && /tmp/aws/install \
+    && rm awscliv2.zip \
+  ) \
+    || pip3 install --no-cache-dir awscli
+}
+
+function install_gitlfs() {
+  local DPKG_ARCH="$(dpkg --print-architecture)"
+
+  curl -s "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${DPKG_ARCH}-v${GIT_LFS_VERSION}.tar.gz" -L -o /tmp/lfs.tar.gz
+  tar -xzf /tmp/lfs.tar.gz -C /tmp
+  /tmp/git-lfs-${GIT_LFS_VERSION}/install.sh
+  rm -rf /tmp/lfs.tar.gz /tmp/git-lfs-${GIT_LFS_VERSION}
+}
+
+function install_docker() {
+  apt-get install -y docker-ce docker-ce-cli docker-buildx-plugin containerd.io docker-compose-plugin --no-install-recommends --allow-unauthenticated
+
+  echo -e '#!/bin/sh\ndocker compose --compatibility "$@"' > /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+
+  sed -i 's/ulimit -Hn/# ulimit -Hn/g' /etc/init.d/docker
+}
+
+function install_container_tools() {
+  ( apt-get install -y --no-install-recommends podman buildah skopeo || : )
+}
+
+function install_githubcli() {
+  local DPKG_ARCH="$(dpkg --print-architecture)"
+
+  GH_CLI_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" \
+    https://api.github.com/repos/cli/cli/releases/latest \
+      | jq -r '.tag_name' | sed 's/^v//g')
+
+  GH_CLI_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" \
+    https://api.github.com/repos/cli/cli/releases/latest \
+      | jq ".assets[] | select(.name == \"gh_${GH_CLI_VERSION}_linux_${DPKG_ARCH}.deb\")" \
+      | jq -r '.browser_download_url')
+
+  curl -sSLo /tmp/ghcli.deb "${GH_CLI_DOWNLOAD_URL}"
+  apt-get -y install /tmp/ghcli.deb
+  rm /tmp/ghcli.deb
+}
+
+function install_yq() {
+  local DPKG_ARCH="$(dpkg --print-architecture)"
+
+  local YQ_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" \
+    https://api.github.com/repos/mikefarah/yq/releases/latest \
+      | jq -r '.tag_name' \
+      | sed 's/^v//g')
+
+  local YQ_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" \
+    https://api.github.com/repos/mikefarah/yq/releases/latest \
+      | jq ".assets[] | select(.name == \"yq_linux_${DPKG_ARCH}.tar.gz\")" \
+      | jq -r '.browser_download_url')
+
+  curl -s "${YQ_DOWNLOAD_URL}" -L -o /tmp/yq.tar.gz
+  tar -xzf /tmp/yq.tar.gz -C /tmp
+  mv /tmp/yq_linux_${DPKG_ARCH} /usr/local/bin/yq
+}
+
+function install_powershell() {
+  local DPKG_ARCH="$(dpkg --print-architecture)"
+
+  local PWSH_VERSION=$(curl -sL -H "Accept: application/vnd.github+json" \
+    https://api.github.com/repos/PowerShell/PowerShell/releases/latest \
+      | jq -r '.tag_name' \
+      | sed 's/^v//g')
+
+  local PWSH_DOWNLOAD_URL=$(curl -sL -H "Accept: application/vnd.github+json" \
+    https://api.github.com/repos/PowerShell/PowerShell/releases/latest \
+      | jq -r ".assets[] | select(.name == \"powershell-${PWSH_VERSION}-linux-${DPKG_ARCH//amd64/x64}.tar.gz\") | .browser_download_url")
+
+  curl -L -o /tmp/powershell.tar.gz "$PWSH_DOWNLOAD_URL"
+  mkdir -p /opt/powershell
+  tar zxf /tmp/powershell.tar.gz -C /opt/powershell
+  chmod +x /opt/powershell/pwsh
+  ln -s /opt/powershell/pwsh /usr/bin/pwsh
+}
+
+function install_tools() {
+  install_git
+  install_liblttng_ust
+  install_awscli
+  install_gitlfs
+  install_docker
+  install_container_tools
+  install_githubcli
+  install_yq
+  install_powershell
+}


### PR DESCRIPTION
Refactored the `Dockerfile.base` out into a set of scripts that install the various tools in mostly the same way, just in a more maintainable and legible way. For my purposes the motivation was to make it easier to strip things out and create a minimal image. I've also changed a few things such as the removal of `lsb-release`, which seemed unnecessary, mainly due to it simplifying the refactoring and to avoid a Python dependency if its not otherwise required. I've tried to make the refactoring steps somewhat easier to follow / diffable via the various commits to make it easier to review.

It does a few less calls to `apt update` given the up-front sources configuration, and so is a touch faster, but it's not significant (a few 10s of seconds on my machine).

I've tested this and for my purposes it works, though I'm not using many of the tools that are installed in this image.

Somewhat related to #380.