### PR TITLE
Automatically Create Runner Groups via GitHub API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /actions-runner/install_actions.sh \
   && rm /actions-runner/install_actions.sh \
   && chown runner /_work /actions-runner /opt/hostedtoolcache
 
-COPY token.sh entrypoint.sh app_token.sh /
+COPY token.sh entrypoint.sh app_token.sh create_group.sh /
 RUN chmod +x /token.sh /entrypoint.sh /app_token.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `RUNNER_TOKEN` | If not using a PAT for `ACCESS_TOKEN` this will be the runner token provided by the Add Runner UI (a manual process). Note: This token is short lived and will change frequently. `ACCESS_TOKEN` is likely preferred. |
 | `RUNNER_WORKDIR` | The working directory for the runner. Runners on the same host should not share this directory. Default is '/_work'. This must match the source path for the bind-mounted volume at RUNNER_WORKDIR, in order for container actions to access files. |
 | `RUNNER_GROUP` | Name of the runner group to add this runner to (defaults to the default runner group) |
+| `CREATE_RUNNER_GROUP` | Boolean to create the specified runner group. If `true`: will create the group specified in `RUNNER_GROUP`; `RUNNER_GROUP` must be set in this case. If any other value the group specified in `RUNNER_GROUP` must already exist. |
 | `GITHUB_HOST` | Optional URL of the Github Enterprise server e.g github.mycompany.com. Defaults to `github.com`. |
 | `DISABLE_AUTOMATIC_DEREGISTRATION` | Optional flag to disable signal catching for deregistration. Default is `false`. Any value other than exactly `false` is considered `true`. See [here](https://github.com/myoung34/docker-github-actions-runner/issues/94) |
 | `CONFIGURED_ACTIONS_RUNNER_FILES_DIR` | Path to use for runner data. It allows avoiding reregistration each the start of the runner. No default value. |

--- a/create_group.sh
+++ b/create_group.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+_GITHUB_HOST=${GITHUB_HOST:="github.com"}
+
+# If URL is not github.com then use the enterprise api endpoint
+if [[ ${GITHUB_HOST} = "github.com" ]]; then
+  URI="https://api.${_GITHUB_HOST}"
+else
+  URI="https://${_GITHUB_HOST}/api/v3"
+fi
+
+API_VERSION=v3
+API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
+AUTH_HEADER="Authorization: token ${ACCESS_TOKEN}"
+
+case ${RUNNER_SCOPE} in
+  org*)
+    _FULL_URL="${URI}/orgs/${ORG_NAME}/actions/runner-groups"
+    ;;
+
+  ent*)
+    _FULL_URL="${URI}/enterprises/${ENTERPRISE_NAME}/actions/runner-groups"
+    ;;
+
+  *)
+    _PROTO="https://"
+    # shellcheck disable=SC2116
+    _URL="$(echo "${REPO_URL/${_PROTO}/}")"
+    _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
+    _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
+    _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+    _FULL_URL="${URI}/repos/${_ACCOUNT}/${_REPO}/actions/runner-groups"
+    ;;
+esac
+
+echo "Creating runner group ${RUNNER_GROUP}"
+# contains http return body and the status code, separated with a line break
+_RETURN_CODE="$(curl -XPOST -sL \
+  --write-out "%{http_code}" \
+  -H "${AUTH_HEADER}" \
+  -H "${API_HEADER}" \
+  -d "{\"name\":\"${RUNNER_GROUP}\"}" \
+  "${_FULL_URL}")"
+
+# 201 when the group was created, 409 when the group already existed
+if [[ "$(echo "$_RETURN_CODE" | tail -n 1)" == "201" ]] || [[ "$(echo "$_RETURN_CODE" | tail -n 1)" == "409" ]]; then
+  exit 0
+else
+  echo "Error: create runner group failed: $_RETURN_CODE" >&2
+  exit 1
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,9 +51,21 @@ if [[ ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
   fi
 fi
 
+_CREATE_RUNNER_GROUP=${CREATE_RUNNER_GROUP:="false"}
+if [[ -n "${RUNNER_GROUP}" ]] && [[ ${_CREATE_RUNNER_GROUP} == "true" ]]; then
+  ACCESS_TOKEN="${ACCESS_TOKEN}" bash /create_group.sh
+  if [[ $? != 0 ]] ; then
+    echo "ERROR: create_group.sh failed" >&2
+    exit 1
+  fi
+elif [[ ! -n "${RUNNER_GROUP}" ]] && [[ ${_CREATE_RUNNER_GROUP} == "true" ]]; then
+  echo "ERROR: CREATE_RUNNER_GROUP needs RUNNER_GROUP set" >&2
+  exit 1
+fi
+_RUNNER_GROUP=${RUNNER_GROUP:-Default}
+
 _RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work/${_RUNNER_NAME}}
 _LABELS=${LABELS:-default}
-_RUNNER_GROUP=${RUNNER_GROUP:-Default}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 _RUN_AS_ROOT=${RUN_AS_ROOT:="true"}
 _START_DOCKER_SERVICE=${START_DOCKER_SERVICE:="false"}
@@ -171,6 +183,7 @@ unset_config_vars() {
   unset RUNNER_TOKEN
   unset RUNNER_WORKDIR
   unset RUNNER_GROUP
+  unset CREATE_RUNNER_GROUP
   unset GITHUB_HOST
   unset DISABLE_AUTOMATIC_DEREGISTRATION
   unset CONFIGURED_ACTIONS_RUNNER_FILES_DIR


### PR DESCRIPTION
Add the `CREATE_RUNNER_GROUP` environment variable.

Instead of creating runner groups manually via the web interface, this variable creates them automatically on runner startup.

See: https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#create-a-self-hosted-runner-group-for-an-organization