### PR TITLE
Fix RUNNER_WORKDIR not created if part of the folder structure is nonexisting

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -150,7 +150,7 @@ configure_runner() {
       --replace \
       "${ARGS[@]}"
 
-  [[ ! -d "${_RUNNER_WORKDIR}" ]] && mkdir "${_RUNNER_WORKDIR}"
+  [[ ! -d "${_RUNNER_WORKDIR}" ]] && mkdir -p "${_RUNNER_WORKDIR}"
 
 }
 


### PR DESCRIPTION
If a RUNNER_WORKDIR is defined in the environment variables but the parent folder is not mapped to the container, the creation will fail.

**Sample:**
`RUNNER_WORKDIR: /tmp/runner/work`
results in console error
`mkdir: cannot create directory ‘/tmp/runner/work’: No such file or directory`