### PR TITLE
fix app_token.sh

### DIFF
--- a/app_token.sh
+++ b/app_token.sh
@@ -61,7 +61,7 @@ base64url() {
 }
 
 rs256_sign() {
-    openssl dgst -binary -sha256 -sign <(echo "$1")
+    openssl dgst -binary -sha256 -sign echo "$1"
 }
 
 request_access_token() {


### PR DESCRIPTION
I found this from 
https://github.com/myoung34/docker-github-actions-runner/issues/369 

as I was having the same error `Could not read private key from /dev/fd/63` when using APP_PRIVATE_KEY
and after adding app_token.sh to my runner container with this fix, it worked