### PR TITLE
Set fixed Docker GID to avoid collisions with some groups

### DIFF
--- a/build/config.json
+++ b/build/config.json
@@ -1,7 +1,8 @@
 {
   "user": {
     "user-id": 1001,
-    "group-id": 121
+    "group-id": 121,
+    "docker-group-id": 500
   },
   "install": [
     {

--- a/build/config.sh
+++ b/build/config.sh
@@ -13,6 +13,10 @@ function group_id() {
   jq -r '.user."group-id"' "$(config_file)"
 }
 
+function docker_group_id() {
+  jq -r '.user."docker-group-id"' "$(config_file)"
+}
+
 function apt_packages() {
   jq -r '.install[] | select(.source == "apt") | .packages[]' "$(config_file)" | paste -sd ' ' -
 }

--- a/build/install_base.sh
+++ b/build/install_base.sh
@@ -50,6 +50,8 @@ install_essentials
 configure_sources
 
 apt-get update
+# The docker group needs to run before installers
+groupadd -g "$(docker_group_id)" docker || :
 install_tools_apt
 install_tools
 

--- a/build/tools.sh
+++ b/build/tools.sh
@@ -38,25 +38,11 @@ function install_git-lfs() {
   rm -rf /tmp/lfs.tar.gz "/tmp/git-lfs-${GIT_LFS_VERSION}"
 }
 
-function configure_docker_group_id() {
-  local desired_gid="$(docker_group_id)"
-  local current_gid=$(getent group docker | cut -d: -f3)
-
-  if [[ "$current_gid" != "$desired_gid" ]]; then
-    # Expected to fail if the group already exists or the GID is already in use
-    groupadd --system --gid "$desired_gid" docker 2>/dev/null || true
-  fi
-}
-
 function install_docker-cli() {
-  configure_docker_group_id
-
   apt-get install -y docker-ce-cli --no-install-recommends --allow-unauthenticated
 }
 
 function install_docker() {
-  configure_docker_group_id
-
   apt-get install -y docker-ce docker-ce-cli docker-buildx-plugin containerd.io docker-compose-plugin --no-install-recommends --allow-unauthenticated
 
   echo -e '#!/bin/sh\ndocker compose --compatibility "$@"' > /usr/local/bin/docker-compose

--- a/build/tools.sh
+++ b/build/tools.sh
@@ -38,11 +38,25 @@ function install_git-lfs() {
   rm -rf /tmp/lfs.tar.gz "/tmp/git-lfs-${GIT_LFS_VERSION}"
 }
 
+function configure_docker_group_id() {
+  local desired_gid="$(docker_group_id)"
+  local current_gid=$(getent group docker | cut -d: -f3)
+
+  if [[ "$current_gid" != "$desired_gid" ]]; then
+    # Expected to fail if the group already exists or the GID is already in use
+    groupadd --system --gid "$desired_gid" docker 2>/dev/null || true
+  fi
+}
+
 function install_docker-cli() {
+  configure_docker_group_id
+
   apt-get install -y docker-ce-cli --no-install-recommends --allow-unauthenticated
 }
 
 function install_docker() {
+  configure_docker_group_id
+
   apt-get install -y docker-ce docker-ce-cli docker-buildx-plugin containerd.io docker-compose-plugin --no-install-recommends --allow-unauthenticated
 
   echo -e '#!/bin/sh\ndocker compose --compatibility "$@"' > /usr/local/bin/docker-compose

--- a/goss_base.yaml
+++ b/goss_base.yaml
@@ -87,3 +87,6 @@ group:
     runner:
         exists: true
         gid: 121
+    docker:
+        exists: true
+        gid: 500


### PR DESCRIPTION
Stabilise Docker GID to Prevent Conflicts With Base System Services

This PR resolves an issue where the Docker group GID changes unpredictably between image builds. This instability causes failures in Docker-related operations, especially when using the image in containerised GitHub Actions workflows (runs_on: container).


Across recent GitHub Actions Runner  image releases (e.g., 2.328.0 to 2.330.0), the GID assigned to the docker group has been inconsistent, landing somewhere in the 990–999 range.

Example 
```
GH_RUNNER_VERSION=2.328.0
polkitd:x:997:
docker:x:996:runner
runner:x:121:

and with:
GH_RUNNER_VERSION=2.329.0
docker:x:999:runner
runner:x:121:
```
 This GID drift breaks downstream images, the underlying cause is that several system services installed before Docker create groups that occupy the upper-range GIDs first. As a result, by the time the Docker package installs, the expected GID is already taken.


Common conflicting system groups include:
```
systemd-journal:x:999:
systemd-network:x:998:
polkitd:x:997:
```


To prevent future collisions, the PR pre-creates the docker group before any Docker-related installation occurs, assigning it a fixed, safe GID.

Docker group GID is now fixed at 500.
* The 500–700 range is widely considered a safe zone for non-core service accounts
* This ensures consistent behaviour across different base OS versions and avoids accidental overlap with systemd, polkit, or other system services.


Looking forward to hearing your feedback.  