### PR TITLE
Adding Docker Swarm secrets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `DEBUG_OUTPUT` | Optional boolean to print additional debug output. Default: false |
 | `UNSET_CONFIG_VARS` | Optional flag to unset all configuration environment variables after runner setup but before starting the runner. This prevents these variables from leaking into the workflow environment. Set to 'true' to enable. Defaults to 'false' for backward compatibility. |
 
+## Docker Swarm Secrets ##
+
+Docker Swarm secrets configuration is available to be configured for `ACCESS_TOKEN`, `RUNNER_TOKEN`, `APP_ID` and `APP_PRIVATE_KEY`.
+
+If a docker secret is configured for the variable then that environment variable will be overrided.
+See https://docs.docker.com/engine/swarm/secrets for more details on how to use secrets.
+
 ## Tests ##
 
 Tests are written in [goss](https://github.com/goss-org/goss/) for general assertions.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,21 @@
 export RUNNER_ALLOW_RUNASROOT=1
 export PATH=${PATH}:/actions-runner
 
+# Function to read secrets from file in a Docker Swarm setup
+read_secret() {
+  local secret_name="$1"
+  local secret_file="/run/secrets/${secret_name}"
+  if [ -f "${secret_file}" ]; then
+    export "${secret_name}"="$(cat ${secret_file})"
+  fi
+}
+
+# Read Docker secrets if available
+read_secret "ACCESS_TOKEN"
+read_secret "RUNNER_TOKEN"
+read_secret "APP_ID"
+read_secret "APP_PRIVATE_KEY"
+
 # Un-export these, so that they must be passed explicitly to the environment of
 # any command that needs them.  This may help prevent leaks.
 export -n ACCESS_TOKEN


### PR DESCRIPTION
Adding support for Docker Swarm secrets as option for sensitive variables.

And as a better solution for this issue, when running in a Docker Swarm environment, https://github.com/myoung34/docker-github-actions-runner/issues/278 