### PR TITLE
feat(entrypoint): add support for RUNNER_LABELS env var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ if [[ ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
 fi
 
 _RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work/${_RUNNER_NAME}}
-_LABELS=${LABELS:-default}
+_LABELS=${RUNNER_LABELS:-${LABELS:-default}}
 _RUNNER_GROUP=${RUNNER_GROUP:-Default}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 _RUN_AS_ROOT=${RUN_AS_ROOT:="true"}


### PR DESCRIPTION
## Summary
This PR updates the `entrypoint.sh` script to check for the `RUNNER_LABELS` environment variable before falling back to `LABELS` or the default value.

## Motivation
The official [Actions Runner Controller (ARC)](https://github.com/actions/actions-runner-controller) Helm charts inject runner labels using the environment variable `RUNNER_LABELS`, whereas this image currently expects `LABELS`.

By prioritizing `RUNNER_LABELS`, we improve compatibility for users attempting to use this Docker image with the official ARC deployment manifests without needing to manually map environment variables.

## Changes
- Modified `entrypoint.sh` to set `_LABELS` using the logic: `RUNNER_LABELS` -> `LABELS` -> `default`.

## Testing
- [x] Verified that passing `RUNNER_LABELS` correctly sets the runner labels.
- [x] Verified that passing `LABELS` (legacy method) still works as a fallback.
- [x] Verified that omitting both still results in `default`.