### PR TITLE
Fix EPHEMERAL=false incorrectly enabling ephemeral mode

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -137,7 +137,7 @@ configure_runner() {
   fi
 
   # shellcheck disable=SC2153
-  if [ -n "${EPHEMERAL}" ]; then
+  if [ "${EPHEMERAL}" = "true" ] || [ "${EPHEMERAL}" = "1" ]; then
     echo "Ephemeral option is enabled"
     ARGS+=("--ephemeral")
   fi


### PR DESCRIPTION
## Summary

- Fix `EPHEMERAL` check to use explicit truthy value comparison instead of `-n` (non-empty check)
- `EPHEMERAL=false` no longer incorrectly enables ephemeral mode

Fixes #1

## Changes

```diff
- if [ -n "${EPHEMERAL}" ]; then
+ if [ "${EPHEMERAL}" = "true" ] || [ "${EPHEMERAL}" = "1" ]; then
```

## Test plan

- [ ] `EPHEMERAL=true` enables ephemeral mode
- [ ] `EPHEMERAL=1` enables ephemeral mode
- [ ] `EPHEMERAL=false` does NOT enable ephemeral mode
- [ ] `EPHEMERAL` unset does NOT enable ephemeral mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)