### PR TITLE
Fix boolean env vars incorrectly enabled when set to false

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -137,17 +137,17 @@ configure_runner() {
   fi
 
   # shellcheck disable=SC2153
-  if [ -n "${EPHEMERAL}" ]; then
+  if [ "${EPHEMERAL}" = "true" ] || [ "${EPHEMERAL}" = "1" ]; then
     echo "Ephemeral option is enabled"
     ARGS+=("--ephemeral")
   fi
 
-  if [ -n "${DISABLE_AUTO_UPDATE}" ]; then
+  if [ "${DISABLE_AUTO_UPDATE}" = "true" ] || [ "${DISABLE_AUTO_UPDATE}" = "1" ]; then
     echo "Disable auto update option is enabled"
     ARGS+=("--disableupdate")
   fi
 
-  if [ -n "${NO_DEFAULT_LABELS}" ]; then
+  if [ "${NO_DEFAULT_LABELS}" = "true" ] || [ "${NO_DEFAULT_LABELS}" = "1" ]; then
     echo "Disable adding the default self-hosted, platform, and architecture labels"
     ARGS+=("--no-default-labels")
   fi


### PR DESCRIPTION
## Summary

`EPHEMERAL`, `DISABLE_AUTO_UPDATE`, and `NO_DEFAULT_LABELS` use `-n` to check if the variable is non-empty. This causes `VAR=false` to still enable the option since `"false"` is a non-empty string.

Now explicitly checks for truthy values: `"true"` or `"1"`.

## Root Cause

Introduced in commit [`63b7a68`](https://github.com/myoung34/docker-github-actions-runner/commit/63b7a683adb6b18e861a9089ee3a5f1052763904) ("Support --ephemeral runner option", Nov 24, 2021).

## Documentation Inconsistency

The README shows inconsistent behavior across similar boolean-like variables:

| Variable | Documentation | Example | Actual Behavior |
|----------|---------------|---------|-----------------|
| `EPHEMERAL` | No specification | `EPHEMERAL=true` | Any non-empty value enables it ❌ |
| `DISABLE_AUTO_UPDATE` | "Any value is considered truthy" | `DISABLE_AUTO_UPDATE=true` | Any non-empty value enables it ❌ |
| `NO_DEFAULT_LABELS` | "Any value is considered truthy" | N/A | Any non-empty value enables it ❌ |
| `DISABLE_AUTOMATIC_DEREGISTRATION` | "Any value other than exactly `false` is considered `true`" | `=true` | Checks `== "false"` ✅ |

This PR aligns the behavior with `DISABLE_AUTOMATIC_DEREGISTRATION` by checking for explicit truthy values.

## Changes

```diff
- if [ -n "${EPHEMERAL}" ]; then
+ if [ "${EPHEMERAL}" = "true" ] || [ "${EPHEMERAL}" = "1" ]; then

- if [ -n "${DISABLE_AUTO_UPDATE}" ]; then
+ if [ "${DISABLE_AUTO_UPDATE}" = "true" ] || [ "${DISABLE_AUTO_UPDATE}" = "1" ]; then

- if [ -n "${NO_DEFAULT_LABELS}" ]; then
+ if [ "${NO_DEFAULT_LABELS}" = "true" ] || [ "${NO_DEFAULT_LABELS}" = "1" ]; then
```

## Test plan

- [ ] `EPHEMERAL=true` enables ephemeral mode
- [ ] `EPHEMERAL=false` does NOT enable ephemeral mode
- [ ] `DISABLE_AUTO_UPDATE=true` disables auto updates
- [ ] `DISABLE_AUTO_UPDATE=false` does NOT disable auto updates
- [ ] `NO_DEFAULT_LABELS=true` disables default labels
- [ ] `NO_DEFAULT_LABELS=false` does NOT disable default labels