### PR TITLE
[WIP] bash cleanup + minor changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /actions-runner/install_actions.sh \
   && rm /actions-runner/install_actions.sh \
   && chown runner /_work /actions-runner /opt/hostedtoolcache
 
-COPY token.sh entrypoint.sh app_token.sh common.sh /
+COPY          token.sh  entrypoint.sh  app_token.sh common.sh /
 RUN chmod +x /token.sh /entrypoint.sh /app_token.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x /actions-runner/install_actions.sh \
   && rm /actions-runner/install_actions.sh \
   && chown runner /_work /actions-runner /opt/hostedtoolcache
 
-COPY token.sh entrypoint.sh app_token.sh /
+COPY token.sh entrypoint.sh app_token.sh common.sh /
 RUN chmod +x /token.sh /entrypoint.sh /app_token.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `RUNNER_SCOPE` | The scope the runner will be registered on. Valid values are `repo`, `org` and `ent`. For 'org' and 'enterprise', `ACCESS_TOKEN` is required and `REPO_URL` is unnecessary. If 'org', requires `ORG_NAME`; if 'ent', requires `ENTERPRISE_NAME`. Default is 'repo'. |
 | `ORG_NAME` | The organization name for the runner to register under. Requires `RUNNER_SCOPE` to be 'org'. No default value. |
 | `ENTERPRISE_NAME` | The enterprise name for the runner to register under. Requires `RUNNER_SCOPE` to be 'enterprise'. No default value. |
-| `LABELS` | A comma separated string to indicate the labels. Default is 'default' |
+| `LABELS` | A comma separated string to indicate the labels. Default is 'default'. Overridden by `RUNNER_LABELS` env var if defined, see the [change](https://github.com/myoung34/docker-github-actions-runner/commit/ac80687f5e2a3a34b11a80daa6089281f186c2d5) |
 | `REPO_URL` | If using a non-organization runner this is the full repository url to register under such as 'https://github.com/myoung34/repo' |
 | `RUNNER_TOKEN` | If not using a PAT for `ACCESS_TOKEN` this will be the runner token provided by the Add Runner UI (a manual process). Note: This token is short lived and will change frequently. `ACCESS_TOKEN` is likely preferred. |
 | `RUNNER_WORKDIR` | The working directory for the runner. Runners on the same host should not share this directory. Default is '/_work'. This must match the source path for the bind-mounted volume at RUNNER_WORKDIR, in order for container actions to access files. |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `NO_DEFAULT_LABELS` | Optional environment variable to disable adding the default self-hosted, platform, and architecture labels to the runner. Any value is considered truthy and will disable them. |
 | `DEBUG_ONLY` | Optional boolean to print debug output but not run any actual registration or runner commands. Used in CI and testing. Default: false |
 | `DEBUG_OUTPUT` | Optional boolean to print additional debug output. Default: false |
-| `UNSET_CONFIG_VARS` | Optional flag to unset most configuration environment variables after runner setup but before starting the runner. This prevents these variables from leaking into the workflow environment. This setting is ignored if `DISABLE_AUTOMATIC_DEREGISTRATION=false`. Set to 'true' to enable. Defaults to 'false' for backward compatibility. |
+| `UNSET_CONFIG_VARS` | Optional flag to unset most configuration environment variables after runner setup but before starting the runner. This prevents these variables from leaking into the workflow environment. Set to 'true' to enable. Defaults to 'false' for backward compatibility. |
 
 ## Tests ##
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `NO_DEFAULT_LABELS` | Optional environment variable to disable adding the default self-hosted, platform, and architecture labels to the runner. Any value is considered truthy and will disable them. |
 | `DEBUG_ONLY` | Optional boolean to print debug output but not run any actual registration or runner commands. Used in CI and testing. Default: false |
 | `DEBUG_OUTPUT` | Optional boolean to print additional debug output. Default: false |
-| `UNSET_CONFIG_VARS` | Optional flag to unset all configuration environment variables after runner setup but before starting the runner. This prevents these variables from leaking into the workflow environment. Set to 'true' to enable. Defaults to 'false' for backward compatibility. |
+| `UNSET_CONFIG_VARS` | Optional flag to unset most configuration environment variables after runner setup but before starting the runner. This prevents these variables from leaking into the workflow environment. This setting is ignored if `DISABLE_AUTOMATIC_DEREGISTRATION=false`. Set to 'true' to enable. Defaults to 'false' for backward compatibility. |
 
 ## Tests ##
 

--- a/app_token.sh
+++ b/app_token.sh
@@ -40,6 +40,8 @@ JWT_JOSE_HEADER='{
 
 
 build_jwt_payload() {
+    local now iat
+
     now=$(date +%s)
     iat=$((now - JWT_IAT_DRIFT))
     jq -c \
@@ -65,6 +67,9 @@ rs256_sign() {
 }
 
 request_access_token() {
+    local jwt_payload encoded_jwt_parts encoded_mac generated_jwt auth_header
+    local app_installations_response access_token_url
+
     jwt_payload=$(build_jwt_payload)
     encoded_jwt_parts=$(base64url <<<"${JWT_JOSE_HEADER}").$(base64url <<<"${jwt_payload}")
     encoded_mac=$(echo -n "${encoded_jwt_parts}" | rs256_sign "${APP_PRIVATE_KEY}" | base64url)
@@ -79,6 +84,7 @@ request_access_token() {
     )
     access_token_url=$(echo "${app_installations_response}" | \
         jq --raw-output '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id  == '"${APP_ID}"') .access_tokens_url')
+
     curl -sX POST \
         -H "${CONTENT_LENGTH_HEADER}" \
         -H "${auth_header}" \

--- a/app_token.sh
+++ b/app_token.sh
@@ -12,8 +12,6 @@
 set -o pipefail
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
-: "${GITHUB_HOST:=github.com}"
-
 # If URL is not github.com then use the enterprise api endpoint
 if [[ ${GITHUB_HOST} == "github.com" ]]; then
   URI="https://api.${GITHUB_HOST}"

--- a/app_token.sh
+++ b/app_token.sh
@@ -12,17 +12,9 @@
 set -o pipefail
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
-# If URL is not github.com then use the enterprise api endpoint
-if [[ ${GITHUB_HOST} == "github.com" ]]; then
-  URI="https://api.${GITHUB_HOST}"
-else
-  URI="https://${GITHUB_HOST}/api/v3"
-fi
-
-API_VERSION=v3
 API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
 CONTENT_LENGTH_HEADER="Content-Length: 0"
-APP_INSTALLATIONS_URI="${URI}/app/installations"
+APP_INSTALLATIONS_URI="${GH_API_ROOT}/app/installations"  # https://docs.github.com/en/rest/apps/apps#list-installations-for-the-authenticated-app
 
 
 # JWT parameters based off
@@ -65,9 +57,33 @@ rs256_sign() {
     openssl dgst -binary -sha256 -sign <(echo "$1")
 }
 
+# verify expected permissions have been granted to the App
+verify_permissions() {
+    local app perms k v
+    app="$1"  # json blob
+
+    declare -A perms
+    perms=(
+        [actions]=read
+        [administration]=write
+        [metadata]=read
+    )
+    [[ "$RUNNER_SCOPE" == org ]] && perms+=(
+        [organization_administration]=read
+        [organization_self_hosted_runners]=write
+    )
+    for k in "${!perms[@]}"; do
+        v="$(jq -r ".permissions.$k" <<< "$app")"
+        [[ "${perms[$k]}" == read && "$v" == write ]] && continue  # write granted where only read required, all good
+        if [[ "$v" != "${perms[$k]}" ]]; then
+            fail "app [$APP_ID] is missing [$k = ${perms[$k]}] permission, has [$k = $v]"
+        fi
+    done
+}
+
 request_access_token() {
     local jwt_payload encoded_jwt_parts encoded_mac generated_jwt auth_header
-    local app_installations_response access_token_url
+    local app_installations_response app access_token_url
 
     jwt_payload=$(build_jwt_payload) || fail "JWT payload construction failed w/ $?"
     encoded_jwt_parts=$(base64url <<<"${JWT_JOSE_HEADER}").$(base64url <<<"${jwt_payload}")
@@ -81,8 +97,12 @@ request_access_token() {
         -H "${API_HEADER}" \
         "${APP_INSTALLATIONS_URI}" \
     ) || fail "fetching $APP_INSTALLATIONS_URI failed w/ $?"
-    access_token_url=$(echo "${app_installations_response}" | \
-        jq -re '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id  == '"${APP_ID}"') .access_tokens_url') || fail "no [.access_token_url] found"
+
+    app=$(jq -re '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id == '"${APP_ID}"')' \
+        <<< "$app_installations_response") || fail "couldn't find app with APP_LOGIN=$APP_LOGIN & APP_ID=$APP_ID in $APP_INSTALLATIONS_URI response"
+    verify_permissions "$app"
+
+    access_token_url=$(jq -re .access_tokens_url <<< "$app") || fail "no [.access_token_url] found in $APP_INSTALLATIONS_URI response"
 
     curl -fsX POST \
         -H "${CONTENT_LENGTH_HEADER}" \

--- a/app_token.sh
+++ b/app_token.sh
@@ -35,7 +35,7 @@ build_jwt_payload() {
 
     now=$(date +%s)
     iat=$((now - JWT_IAT_DRIFT))
-    jq -ce \
+    jq -cej \
         --arg iat_str "${iat}" \
         --arg exp_delta_str "${JWT_EXP_DELTA}" \
         --arg app_id_str "${APP_ID}" \
@@ -46,7 +46,7 @@ build_jwt_payload() {
         | .iat = $iat
         | .exp = ($iat + $exp_delta)
         | .iss = $app_id
-    ' <<< '{}' | tr -d '\n'
+    ' <<< '{}'
 }
 
 base64url() {

--- a/app_token.sh
+++ b/app_token.sh
@@ -12,7 +12,7 @@
 set -o pipefail
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
-API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
+API_HEADER="Accept: application/vnd.github.${GH_API_VER}+json"
 CONTENT_LENGTH_HEADER="Content-Length: 0"
 APP_INSTALLATIONS_URI="${GH_API_ROOT}/app/installations"  # https://docs.github.com/en/rest/apps/apps#list-installations-for-the-authenticated-app
 

--- a/app_token.sh
+++ b/app_token.sh
@@ -11,13 +11,13 @@
 
 set -o pipefail
 
-_GITHUB_HOST=${GITHUB_HOST:="github.com"}
+: "${GITHUB_HOST:=github.com}"
 
 # If URL is not github.com then use the enterprise api endpoint
 if [[ ${GITHUB_HOST} == "github.com" ]]; then
-  URI="https://api.${_GITHUB_HOST}"
+  URI="https://api.${GITHUB_HOST}"
 else
-  URI="https://${_GITHUB_HOST}/api/v3"
+  URI="https://${GITHUB_HOST}/api/v3"
 fi
 
 API_VERSION=v3

--- a/app_token.sh
+++ b/app_token.sh
@@ -44,7 +44,7 @@ build_jwt_payload() {
 
     now=$(date +%s)
     iat=$((now - JWT_IAT_DRIFT))
-    jq -c \
+    jq -ce \
         --arg iat_str "${iat}" \
         --arg exp_delta_str "${JWT_EXP_DELTA}" \
         --arg app_id_str "${APP_ID}" \
@@ -70,27 +70,26 @@ request_access_token() {
     local jwt_payload encoded_jwt_parts encoded_mac generated_jwt auth_header
     local app_installations_response access_token_url
 
-    jwt_payload=$(build_jwt_payload)
+    jwt_payload=$(build_jwt_payload) || exit $?
     encoded_jwt_parts=$(base64url <<<"${JWT_JOSE_HEADER}").$(base64url <<<"${jwt_payload}")
     encoded_mac=$(echo -n "${encoded_jwt_parts}" | rs256_sign "${APP_PRIVATE_KEY}" | base64url)
     generated_jwt="${encoded_jwt_parts}.${encoded_mac}"
 
     auth_header="Authorization: Bearer ${generated_jwt}"
 
-    app_installations_response=$(curl -sX GET \
+    app_installations_response=$(curl -fs \
         -H "${auth_header}" \
         -H "${API_HEADER}" \
         "${APP_INSTALLATIONS_URI}" \
-    )
+    ) || { echo "FAIL: curling $APP_INSTALLATIONS_URI failed w/ $?" >&2; exit 1; }
     access_token_url=$(echo "${app_installations_response}" | \
-        jq --raw-output '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id  == '"${APP_ID}"') .access_tokens_url')
+        jq -re '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id  == '"${APP_ID}"') .access_tokens_url') || exit $?
 
-    curl -sX POST \
+    curl -fsX POST \
         -H "${CONTENT_LENGTH_HEADER}" \
         -H "${auth_header}" \
         -H "${API_HEADER}" \
-        "${access_token_url}" | \
-        jq --raw-output .token
+        "${access_token_url}" | jq -re .token || exit $?
 }
 
 request_access_token

--- a/app_token.sh
+++ b/app_token.sh
@@ -10,6 +10,7 @@
 #
 
 set -o pipefail
+source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
 : "${GITHUB_HOST:=github.com}"
 
@@ -70,7 +71,7 @@ request_access_token() {
     local jwt_payload encoded_jwt_parts encoded_mac generated_jwt auth_header
     local app_installations_response access_token_url
 
-    jwt_payload=$(build_jwt_payload) || exit $?
+    jwt_payload=$(build_jwt_payload) || fail "JWT payload construction failed w/ $?"
     encoded_jwt_parts=$(base64url <<<"${JWT_JOSE_HEADER}").$(base64url <<<"${jwt_payload}")
     encoded_mac=$(echo -n "${encoded_jwt_parts}" | rs256_sign "${APP_PRIVATE_KEY}" | base64url)
     generated_jwt="${encoded_jwt_parts}.${encoded_mac}"
@@ -81,15 +82,15 @@ request_access_token() {
         -H "${auth_header}" \
         -H "${API_HEADER}" \
         "${APP_INSTALLATIONS_URI}" \
-    ) || { echo "FAIL: curling $APP_INSTALLATIONS_URI failed w/ $?" >&2; exit 1; }
+    ) || fail "fetching $APP_INSTALLATIONS_URI failed w/ $?"
     access_token_url=$(echo "${app_installations_response}" | \
-        jq -re '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id  == '"${APP_ID}"') .access_tokens_url') || exit $?
+        jq -re '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id  == '"${APP_ID}"') .access_tokens_url') || fail "no [.access_token_url] found"
 
     curl -fsX POST \
         -H "${CONTENT_LENGTH_HEADER}" \
         -H "${auth_header}" \
         -H "${API_HEADER}" \
-        "${access_token_url}" | jq -re .token || exit $?
+        "${access_token_url}" | jq -re .token || fail "$access_token_url fetch & [.token] extraction failed with $?"
 }
 
 request_access_token

--- a/app_token.sh
+++ b/app_token.sh
@@ -14,7 +14,7 @@ set -o pipefail
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 
 # If URL is not github.com then use the enterprise api endpoint
-if [[ ${GITHUB_HOST} = "github.com" ]]; then
+if [[ ${GITHUB_HOST} == "github.com" ]]; then
   URI="https://api.${_GITHUB_HOST}"
 else
   URI="https://${_GITHUB_HOST}/api/v3"
@@ -53,7 +53,7 @@ build_jwt_payload() {
         | .iat = $iat
         | .exp = ($iat + $exp_delta)
         | .iss = $app_id
-    ' <<< "{}" | tr -d '\n'
+    ' <<< '{}' | tr -d '\n'
 }
 
 base64url() {
@@ -77,7 +77,8 @@ request_access_token() {
         -H "${API_HEADER}" \
         "${APP_INSTALLATIONS_URI}" \
     )
-    access_token_url=$(echo "${app_installations_response}" | jq --raw-output '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id  == '"${APP_ID}"') .access_tokens_url')
+    access_token_url=$(echo "${app_installations_response}" | \
+        jq --raw-output '.[] | select (.account.login == "'"${APP_LOGIN}"'" and .app_id  == '"${APP_ID}"') .access_tokens_url')
     curl -sX POST \
         -H "${CONTENT_LENGTH_HEADER}" \
         -H "${auth_header}" \

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/dumb-init /bin/bash
+# shellcheck shell=bash
+log() {
+    local level
+    level="$1"; shift
+    echo -e "$level: $*" 1>&2
+}
+
+fail() {
+    log FAIL "$*"
+    exit 1
+}
+
+trap_with_arg() {
+    local func
+    func="$1"; shift
+    for sig; do
+        # shellcheck disable=SC2064
+        trap "$func $sig" "$sig"
+    done
+}

--- a/common.sh
+++ b/common.sh
@@ -11,8 +11,8 @@ fail() {
     exit 1
 }
 
-trap_with_arg() {
-    local func
+trap_with_sig() {
+    local func sig
     func="$1"; shift
     for sig; do
         # shellcheck disable=SC2064

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,37 +41,31 @@ deregister_runner() {
   exit
 }
 
-_DEBUG_ONLY=${DEBUG_ONLY:-false}
-_DEBUG_OUTPUT=${DEBUG_OUTPUT:-false}
-_DISABLE_AUTOMATIC_DEREGISTRATION=${DISABLE_AUTOMATIC_DEREGISTRATION:-false}
+: "${DEBUG_ONLY:=false}"
+: "${DEBUG_OUTPUT:=false}"
+: "${DISABLE_AUTOMATIC_DEREGISTRATION:=false}"
+: "${RANDOM_RUNNER_SUFFIX:=true}"
 
-_RANDOM_RUNNER_SUFFIX=${RANDOM_RUNNER_SUFFIX:="true"}
-
-_RUNNER_NAME=${RUNNER_NAME:-${RUNNER_NAME_PREFIX:-github-runner}-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13; echo '')}
-if [[ ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
-  # In some cases this file does not exist
+if [[ -z "$RUNNER_NAME" && ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
   if [[ -s "/etc/hostname" ]]; then
-    # in some cases it can also be empty
-    if [[ $(stat --printf="%s" /etc/hostname) -ne 0 ]]; then
-      _RUNNER_NAME_PREFIX=${RUNNER_NAME_PREFIX-"github-runner"}
-      _RUNNER_NAME=${RUNNER_NAME:-${_RUNNER_NAME_PREFIX:+${_RUNNER_NAME_PREFIX}-}$(cat /etc/hostname)}
-      echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX}. /etc/hostname exists and has content. Setting runner name to ${_RUNNER_NAME}"
-    else
-      echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} ./etc/hostname exists but is empty. Not using /etc/hostname"
-    fi
+    _RUNNER_NAME_PREFIX=${RUNNER_NAME_PREFIX-'github-runner'}
+    RUNNER_NAME=${_RUNNER_NAME_PREFIX:+${_RUNNER_NAME_PREFIX}-}$(cat /etc/hostname)
+    echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX}. /etc/hostname exists and has content. Setting runner name to ${RUNNER_NAME}"
   else
-    echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} but /etc/hostname does not exist. Not using /etc/hostname"
+    echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} but /etc/hostname is not a non-empty file. Not using it"
   fi
 fi
+: "${RUNNER_NAME:=${RUNNER_NAME_PREFIX:-github-runner}-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')}"
 
-_RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work/${_RUNNER_NAME}}
-_LABELS=${RUNNER_LABELS:-${LABELS:-default}}
-_RUNNER_GROUP=${RUNNER_GROUP:-Default}
-_GITHUB_HOST=${GITHUB_HOST:="github.com"}
-_RUN_AS_ROOT=${RUN_AS_ROOT:="true"}
-_START_DOCKER_SERVICE=${START_DOCKER_SERVICE:="false"}
-_UNSET_CONFIG_VARS=${UNSET_CONFIG_VARS:="false"}
-_CONFIGURED_ACTIONS_RUNNER_FILES_DIR=${CONFIGURED_ACTIONS_RUNNER_FILES_DIR:-''}
+: "${RUNNER_WORKDIR:=/_work/${RUNNER_NAME}}"
+: "${RUNNER_GROUP:=Default}"
+: "${GITHUB_HOST:=github.com}"
+: "${RUN_AS_ROOT:=true}"
+: "${START_DOCKER_SERVICE:=false}"
+: "${UNSET_CONFIG_VARS:=false}"
+: "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR:=''}"
+# as to why $RUNNER_LABELS is used, see https://github.com/myoung34/docker-github-actions-runner/commit/ac80687f5e2a3a34b11a80daa6089281f186c2d5
+LABELS=${RUNNER_LABELS:-${LABELS:-default}}
 
 # ensure backwards compatibility
 if [[ -z ${RUNNER_SCOPE} ]]; then
@@ -88,7 +82,7 @@ RUNNER_SCOPE="${RUNNER_SCOPE,,}"  # to lowercase
 case "${RUNNER_SCOPE}" in
   org*)
     [[ -z ${ORG_NAME} ]] && fail "ORG_NAME required for org runners"
-    _SHORT_URL="https://${_GITHUB_HOST}/${ORG_NAME}"
+    _SHORT_URL="https://${GITHUB_HOST}/${ORG_NAME}"
     RUNNER_SCOPE="org"
     if [[ -n "${APP_ID}" && -z "${APP_LOGIN}" ]]; then
       APP_LOGIN=${ORG_NAME}
@@ -97,7 +91,7 @@ case "${RUNNER_SCOPE}" in
 
   ent*)
     [[ -z ${ENTERPRISE_NAME} ]] && fail "ENTERPRISE_NAME required for enterprise runners"
-    _SHORT_URL="https://${_GITHUB_HOST}/enterprises/${ENTERPRISE_NAME}"
+    _SHORT_URL="https://${GITHUB_HOST}/enterprises/${ENTERPRISE_NAME}"
     RUNNER_SCOPE="enterprise"
     ;;
 
@@ -157,15 +151,15 @@ configure_runner() {
   ./config.sh \
       --url "${_SHORT_URL}" \
       --token "${RUNNER_TOKEN}" \
-      --name "${_RUNNER_NAME}" \
-      --work "${_RUNNER_WORKDIR}" \
-      --labels "${_LABELS}" \
-      --runnergroup "${_RUNNER_GROUP}" \
+      --name "${RUNNER_NAME}" \
+      --work "${RUNNER_WORKDIR}" \
+      --labels "${LABELS}" \
+      --runnergroup "${RUNNER_GROUP}" \
       --unattended \
       --replace \
       "${args[@]}"
 
-  [[ ! -d "${_RUNNER_WORKDIR}" ]] && mkdir -p "${_RUNNER_WORKDIR}"
+  [[ ! -d "${RUNNER_WORKDIR}" ]] && mkdir -p "${RUNNER_WORKDIR}"
 }
 
 unset_config_vars() {
@@ -197,55 +191,54 @@ unset_config_vars() {
 }
 
 # Opt into runner reusage because a value was given
-if [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
+if [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
   echo "Runner reusage is enabled"
 
   # directory exists, copy the data
-  if [[ -d "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
+  if [[ -d "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
     echo "Copying previous data"
-    cp -pr -- "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/." "/actions-runner"
+    cp -pr -- "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/." "/actions-runner"
   fi
 
   if [[ -f "/actions-runner/.runner" ]]; then
     echo "The runner has already been configured"
   else
-
-    if [[ ${_DEBUG_ONLY} == "false" ]]; then
+    if [[ ${DEBUG_ONLY} == "false" ]]; then
       configure_runner
     fi
   fi
 else
   echo "Runner reusage is disabled"
-  if [[ ${_DEBUG_ONLY} == "false" ]]; then
+  if [[ ${DEBUG_ONLY} == "false" ]]; then
     [[ -f "/actions-runner/.runner" ]] && rm -f /actions-runner/.runner
     configure_runner
   fi
 fi
 
-if [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
-  echo "Reusage is enabled. Storing data to ${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
-  if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
+if [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
+  echo "Reusage is enabled. Storing data to ${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
+  if [[ ${DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
     fail "DISABLE_AUTOMATIC_DEREGISTRATION should be set to true to avoid issues with re-using a deregistered runner"
   fi
   # Quoting (even with double-quotes) the regexp brokes the copying
-  cp -pr "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
+  cp -pr "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
 fi
 
 
 
-if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
-  if [[ ${_DEBUG_ONLY} == "false" ]]; then
+if [[ ${DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
+  if [[ ${DEBUG_ONLY} == "false" ]]; then
     trap_with_arg deregister_runner SIGINT SIGQUIT SIGTERM INT TERM QUIT
   fi
 fi
 
 # Start docker service if needed (e.g. for docker-in-docker)
-if [[ ${_START_DOCKER_SERVICE} == "true" ]]; then
+if [[ ${START_DOCKER_SERVICE} == "true" ]]; then
   echo "Starting docker service"
   _PREFIX=''
-  [[ ${_RUN_AS_ROOT} != "true" ]] && _PREFIX="sudo"
+  [[ ${RUN_AS_ROOT} != "true" ]] && _PREFIX="sudo"
 
-  if [[ ${_DEBUG_ONLY} == "true" ]]; then
+  if [[ ${DEBUG_ONLY} == "true" ]]; then
     echo ${_PREFIX} service docker start
   else
     ${_PREFIX} service docker start
@@ -253,33 +246,33 @@ if [[ ${_START_DOCKER_SERVICE} == "true" ]]; then
 fi
 
 # Unset configuration environment variables if the flag is set
-if [[ ${_UNSET_CONFIG_VARS} == "true" ]]; then
+if [[ ${UNSET_CONFIG_VARS} == "true" ]]; then
   unset_config_vars
 fi
 
 # Container's command (CMD) execution as runner user
 
 
-if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
+if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
   echo ''
-  echo "Disable automatic registration: ${_DISABLE_AUTOMATIC_DEREGISTRATION}"
-  echo "Random runner suffix: ${_RANDOM_RUNNER_SUFFIX}"
-  echo "Runner name: ${_RUNNER_NAME}"
-  echo "Runner workdir: ${_RUNNER_WORKDIR}"
-  echo "Labels: ${_LABELS}"
-  echo "Runner Group: ${_RUNNER_GROUP}"
-  echo "Github Host: ${_GITHUB_HOST}"
-  echo "Run as root:${_RUN_AS_ROOT}"
-  echo "Start docker: ${_START_DOCKER_SERVICE}"
+  echo "Disable automatic registration: ${DISABLE_AUTOMATIC_DEREGISTRATION}"
+  echo "Random runner suffix: ${RANDOM_RUNNER_SUFFIX}"
+  echo "Runner name: ${RUNNER_NAME}"
+  echo "Runner workdir: ${RUNNER_WORKDIR}"
+  echo "Labels: ${LABELS}"
+  echo "Runner Group: ${RUNNER_GROUP}"
+  echo "Github Host: ${GITHUB_HOST}"
+  echo "Run as root:${RUN_AS_ROOT}"
+  echo "Start docker: ${START_DOCKER_SERVICE}"
 fi
 
-if [[ ${_RUN_AS_ROOT} == "true" ]]; then
+if [[ ${RUN_AS_ROOT} == "true" ]]; then
   if [[ $(id -u) -eq 0 ]]; then
-    if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
+    if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
       # shellcheck disable=SC2145
       echo "Running $@"
     fi
-    if [[ ${_DEBUG_ONLY} == "false" ]]; then
+    if [[ ${DEBUG_ONLY} == "false" ]]; then
       "$@"
     fi
   else
@@ -287,23 +280,23 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
   fi
 else
   if [[ $(id -u) -eq 0 ]]; then
-    [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && chown -R runner "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
-    chown -R runner "${_RUNNER_WORKDIR}" /actions-runner
+    [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && chown -R runner "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
+    chown -R runner "${RUNNER_WORKDIR}" /actions-runner
     # The toolcache is not recursively chowned to avoid recursing over prepulated tooling in derived docker images
     chown runner /opt/hostedtoolcache/
-    if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
+    if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
       # shellcheck disable=SC2145
       echo "Running /usr/sbin/gosu runner $@"
     fi
-    if [[ ${_DEBUG_ONLY} == "false" ]]; then
+    if [[ ${DEBUG_ONLY} == "false" ]]; then
       /usr/sbin/gosu runner "$@"
     fi
   else
-    if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
+    if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
       # shellcheck disable=SC2145
       echo "Running $@"
     fi
-    if [[ ${_DEBUG_ONLY} == "false" ]]; then
+    if [[ ${DEBUG_ONLY} == "false" ]]; then
       "$@"
     fi
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -164,7 +164,6 @@ configure_runner() {
 
 unset_config_vars() {
   echo "Unsetting configuration environment variables"
-  unset RUN_AS_ROOT
   unset RUNNER_NAME
   unset RUNNER_NAME_PREFIX
   unset RANDOM_RUNNER_SUFFIX
@@ -224,14 +223,6 @@ if [[ -n "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
   cp -pr "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
 fi
 
-
-
-if [[ ${DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
-  if [[ ${DEBUG_ONLY} == "false" ]]; then
-    trap_with_arg deregister_runner SIGINT SIGQUIT SIGTERM INT TERM QUIT
-  fi
-fi
-
 # Start docker service if needed (e.g. for docker-in-docker)
 if [[ ${START_DOCKER_SERVICE} == "true" ]]; then
   echo "Starting docker service"
@@ -245,13 +236,7 @@ if [[ ${START_DOCKER_SERVICE} == "true" ]]; then
   fi
 fi
 
-# Unset configuration environment variables if the flag is set
-if [[ ${UNSET_CONFIG_VARS} == "true" ]]; then
-  unset_config_vars
-fi
-
 # Container's command (CMD) execution as runner user
-
 
 if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
   echo ''
@@ -262,8 +247,14 @@ if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
   echo "Labels: ${LABELS}"
   echo "Runner Group: ${RUNNER_GROUP}"
   echo "Github Host: ${GITHUB_HOST}"
-  echo "Run as root:${RUN_AS_ROOT}"
+  echo "Run as root: ${RUN_AS_ROOT}"
   echo "Start docker: ${START_DOCKER_SERVICE}"
+fi
+
+if [[ ${DISABLE_AUTOMATIC_DEREGISTRATION} == "false" && ${DEBUG_ONLY} == "false" ]]; then
+  trap_with_sig  deregister_runner SIGINT SIGQUIT SIGTERM INT TERM QUIT
+elif [[ ${UNSET_CONFIG_VARS} == "true" ]]; then
+  unset_config_vars
 fi
 
 if [[ ${RUN_AS_ROOT} == "true" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -258,8 +258,7 @@ fi
 if [[ ${RUN_AS_ROOT} == "true" ]]; then
   if [[ $(id -u) -eq 0 ]]; then
     if [[ "$DEBUG" == true ]]; then
-      # shellcheck disable=SC2145
-      echo "Running $@"
+      echo "Running $*"
     fi
     if [[ ${DEBUG_ONLY} == "false" ]]; then
       "$@"
@@ -274,16 +273,14 @@ else
     # The toolcache is not recursively chowned to avoid recursing over prepulated tooling in derived docker images
     chown runner /opt/hostedtoolcache/
     if [[ "$DEBUG" == true ]]; then
-      # shellcheck disable=SC2145
-      echo "Running /usr/sbin/gosu runner $@"
+      echo "Running /usr/sbin/gosu runner $*"
     fi
     if [[ ${DEBUG_ONLY} == "false" ]]; then
       /usr/sbin/gosu runner "$@"
     fi
   else
     if [[ "$DEBUG" == true ]]; then
-      # shellcheck disable=SC2145
-      echo "Running $@"
+      echo "Running $*"
     fi
     if [[ ${DEBUG_ONLY} == "false" ]]; then
       "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/dumb-init /bin/bash
 # shellcheck shell=bash
+set -o pipefail
 
 export RUNNER_ALLOW_RUNASROOT=1
 export PATH=${PATH}:/actions-runner
@@ -23,12 +24,13 @@ deregister_runner() {
   echo "Caught $1 - Deregistering runner"
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     # If using GitHub App authentication, refresh the access token before deregistration
-    if [[ -n "${APP_ID}" ]] && [[ -n "${APP_PRIVATE_KEY}" ]] && [[ -n "${APP_LOGIN}" ]]; then
+    if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
       echo "Refreshing access token for deregistration"
       nl="
 "
-      NEW_ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
-      if [[ -z "${NEW_ACCESS_TOKEN}" ]] || [[ "${NEW_ACCESS_TOKEN}" == "null" ]]; then
+      NEW_ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
+          APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
+      if [[ -z "${NEW_ACCESS_TOKEN}" || "${NEW_ACCESS_TOKEN}" == "null" ]]; then
         echo "ERROR: Failed to refresh access token for deregistration"
         exit 1
       fi
@@ -52,7 +54,7 @@ _RANDOM_RUNNER_SUFFIX=${RANDOM_RUNNER_SUFFIX:="true"}
 _RUNNER_NAME=${RUNNER_NAME:-${RUNNER_NAME_PREFIX:-github-runner}-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')}
 if [[ ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
   # In some cases this file does not exist
-  if [[ -f "/etc/hostname" ]]; then
+  if [[ -s "/etc/hostname" ]]; then
     # in some cases it can also be empty
     if [[ $(stat --printf="%s" /etc/hostname) -ne 0 ]]; then
       _RUNNER_NAME_PREFIX=${RUNNER_NAME_PREFIX-"github-runner"}
@@ -78,21 +80,21 @@ _CONFIGURED_ACTIONS_RUNNER_FILES_DIR=${CONFIGURED_ACTIONS_RUNNER_FILES_DIR:-""}
 # ensure backwards compatibility
 if [[ -z ${RUNNER_SCOPE} ]]; then
   if [[ ${ORG_RUNNER} == "true" ]]; then
-    echo 'ORG_RUNNER is now deprecated. Please use RUNNER_SCOPE="org" instead.'
-    export RUNNER_SCOPE="org"
+    echo 'ORG_RUNNER env var is now deprecated. Please use RUNNER_SCOPE="org" instead.'
+    RUNNER_SCOPE="org"
   else
-    export RUNNER_SCOPE="repo"
+    RUNNER_SCOPE="repo"
   fi
 fi
 
-RUNNER_SCOPE="${RUNNER_SCOPE,,}" # to lowercase
+RUNNER_SCOPE="${RUNNER_SCOPE,,}"  # to lowercase
 
-case ${RUNNER_SCOPE} in
+case "${RUNNER_SCOPE}" in
   org*)
     [[ -z ${ORG_NAME} ]] && ( echo "ORG_NAME required for org runners"; exit 1 )
     _SHORT_URL="https://${_GITHUB_HOST}/${ORG_NAME}"
     RUNNER_SCOPE="org"
-    if [[ -n "${APP_ID}" ]] && [[ -z "${APP_LOGIN}" ]]; then
+    if [[ -n "${APP_ID}" && -z "${APP_LOGIN}" ]]; then
       APP_LOGIN=${ORG_NAME}
     fi
     ;;
@@ -107,25 +109,28 @@ case ${RUNNER_SCOPE} in
     [[ -z ${REPO_URL} ]] && ( echo "REPO_URL required for repo runners"; exit 1 )
     _SHORT_URL=${REPO_URL}
     RUNNER_SCOPE="repo"
-    if [[ -n "${APP_ID}" ]] && [[ -z "${APP_LOGIN}" ]]; then
+    if [[ -n "${APP_ID}" && -z "${APP_LOGIN}" ]]; then
       APP_LOGIN=${REPO_URL%/*}
       APP_LOGIN=${APP_LOGIN##*/}
     fi
     ;;
 esac
 
+export RUNNER_SCOPE
+
 configure_runner() {
   ARGS=()
-  if [[ -n "${APP_ID}" ]] && [[ -n "${APP_PRIVATE_KEY}" ]] && [[ -n "${APP_LOGIN}" ]]; then
-    if [[ -n "${ACCESS_TOKEN}" ]] || [[ -n "${RUNNER_TOKEN}" ]]; then
+  if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
+    if [[ -n "${ACCESS_TOKEN}" || -n "${RUNNER_TOKEN}" ]]; then
       echo "ERROR: ACCESS_TOKEN or RUNNER_TOKEN provided but are mutually exclusive with APP_ID, APP_PRIVATE_KEY and APP_LOGIN." >&2
       exit 1
     fi
     echo "Obtaining access token for app_id ${APP_ID} and login ${APP_LOGIN}"
     nl="
 "
-    ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
-  elif [[ -n "${APP_ID}" ]] || [[ -n "${APP_PRIVATE_KEY}" ]] || [[ -n "${APP_LOGIN}" ]]; then
+    ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
+        APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
+  elif [[ -n "${APP_ID}" || -n "${APP_PRIVATE_KEY}" || -n "${APP_LOGIN}" ]]; then
     echo "ERROR: All of APP_ID, APP_PRIVATE_KEY and APP_LOGIN must be specified." >&2
     exit 1
   fi
@@ -137,17 +142,17 @@ configure_runner() {
   fi
 
   # shellcheck disable=SC2153
-  if [ -n "${EPHEMERAL}" ]; then
+  if [[ -n "${EPHEMERAL}" ]]; then
     echo "Ephemeral option is enabled"
     ARGS+=("--ephemeral")
   fi
 
-  if [ -n "${DISABLE_AUTO_UPDATE}" ]; then
+  if [[ -n "${DISABLE_AUTO_UPDATE}" ]]; then
     echo "Disable auto update option is enabled"
     ARGS+=("--disableupdate")
   fi
 
-  if [ -n "${NO_DEFAULT_LABELS}" ]; then
+  if [[ -n "${NO_DEFAULT_LABELS}" ]]; then
     echo "Disable adding the default self-hosted, platform, and architecture labels"
     ARGS+=("--no-default-labels")
   fi
@@ -203,10 +208,10 @@ if [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
   # directory exists, copy the data
   if [[ -d "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
     echo "Copying previous data"
-    cp -p -r "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/." "/actions-runner"
+    cp -pr -- "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}/." "/actions-runner"
   fi
 
-  if [ -f "/actions-runner/.runner" ]; then
+  if [[ -f "/actions-runner/.runner" ]]; then
     echo "The runner has already been configured"
   else
 
@@ -261,7 +266,7 @@ fi
 # Container's command (CMD) execution as runner user
 
 
-if [[ ${_DEBUG_ONLY} == "true" ]] || [[ ${_DEBUG_OUTPUT} == "true" ]] ; then
+if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
   echo ""
   echo "Disable automatic registration: ${_DISABLE_AUTOMATIC_DEREGISTRATION}"
   echo "Random runner suffix: ${_RANDOM_RUNNER_SUFFIX}"
@@ -276,7 +281,7 @@ fi
 
 if [[ ${_RUN_AS_ROOT} == "true" ]]; then
   if [[ $(id -u) -eq 0 ]]; then
-    if [[ ${_DEBUG_ONLY} == "true" ]] || [[ ${_DEBUG_OUTPUT} == "true" ]] ; then
+    if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
       # shellcheck disable=SC2145
       echo "Running $@"
     fi
@@ -293,7 +298,7 @@ else
     chown -R runner "${_RUNNER_WORKDIR}" /actions-runner
     # The toolcache is not recursively chowned to avoid recursing over prepulated tooling in derived docker images
     chown runner /opt/hostedtoolcache/
-    if [[ ${_DEBUG_ONLY} == "true" ]] || [[ ${_DEBUG_OUTPUT} == "true" ]] ; then
+    if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
       # shellcheck disable=SC2145
       echo "Running /usr/sbin/gosu runner $@"
     fi
@@ -301,7 +306,7 @@ else
       /usr/sbin/gosu runner "$@"
     fi
   else
-    if [[ ${_DEBUG_ONLY} == "true" ]] || [[ ${_DEBUG_OUTPUT} == "true" ]] ; then
+    if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
       # shellcheck disable=SC2145
       echo "Running $@"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,16 +16,14 @@ export -n APP_PRIVATE_KEY
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
 deregister_runner() {
-  local nl token
+  local token
 
   echo "Caught $1 - Deregistering runner"
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     # If using GitHub App authentication, refresh the access token before deregistration
     if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
       echo "Refreshing access token for deregistration"
-      nl='
-'
-      ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
+      ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/$'\n'}" \
           APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
       if [[ -z "${ACCESS_TOKEN}" || "${ACCESS_TOKEN}" == "null" ]]; then
         fail "Failed to refresh access token for deregistration"
@@ -48,8 +46,8 @@ deregister_runner() {
 
 if [[ -z "$RUNNER_NAME" && ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
   if [[ -s "/etc/hostname" ]]; then
-    _RUNNER_NAME_PREFIX=${RUNNER_NAME_PREFIX-'github-runner'}
-    RUNNER_NAME=${_RUNNER_NAME_PREFIX:+${_RUNNER_NAME_PREFIX}-}$(cat /etc/hostname)
+    _runner_name_prefix=${RUNNER_NAME_PREFIX-'github-runner'}
+    RUNNER_NAME=${_runner_name_prefix:+${_runner_name_prefix}-}$(cat /etc/hostname)
     echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX}. /etc/hostname exists and has content. Setting runner name to ${RUNNER_NAME}"
   else
     echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} but /etc/hostname is not a non-empty file. Not using it"
@@ -106,10 +104,10 @@ case "${RUNNER_SCOPE}" in
     ;;
 esac
 
-export RUNNER_SCOPE
+export RUNNER_SCOPE GITHUB_HOST
 
 configure_runner() {
-  local args nl token
+  local args token
 
   args=()
   if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
@@ -117,12 +115,10 @@ configure_runner() {
       fail "ACCESS_TOKEN or RUNNER_TOKEN provided but are mutually exclusive with {APP_ID, APP_PRIVATE_KEY, APP_LOGIN}"
     fi
     echo "Obtaining access token for app_id ${APP_ID} and login ${APP_LOGIN}"
-    nl='
-'
-    ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
+    ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/$'\n'}" \
         APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
   elif [[ -n "${APP_ID}" || -n "${APP_PRIVATE_KEY}" || -n "${APP_LOGIN}" ]]; then
-    fail "either all or none of APP_ID, APP_PRIVATE_KEY and APP_LOGIN must be specified"
+    fail "either all or none of {APP_ID, APP_PRIVATE_KEY, APP_LOGIN} must be specified"
   fi
 
   if [[ -n "${ACCESS_TOKEN}" ]]; then
@@ -177,11 +173,9 @@ unset_config_vars() {
   unset LABELS
   unset REPO_URL
   unset RUNNER_TOKEN
-  unset RUNNER_WORKDIR
   unset RUNNER_GROUP
   unset GITHUB_HOST
   unset DISABLE_AUTOMATIC_DEREGISTRATION
-  unset CONFIGURED_ACTIONS_RUNNER_FILES_DIR
   unset EPHEMERAL
   unset DISABLE_AUTO_UPDATE
   unset START_DOCKER_SERVICE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,8 +19,6 @@ export -n APP_LOGIN
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
 deregister_runner() {
-  local token
-
   echo "Caught $1 - Deregistering runner"
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     # If using GitHub App authentication, refresh the access token before deregistration
@@ -30,8 +28,7 @@ deregister_runner() {
           APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
       echo "Access token refreshed successfully"
     fi
-    token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
-    RUNNER_TOKEN=$(jq -re .token <<< "$token") || fail "[.token] not found in token.sh output"
+    RUNNER_TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
   fi
 
   ./config.sh remove --token "${RUNNER_TOKEN}"
@@ -115,7 +112,7 @@ esac
 export RUNNER_SCOPE GH_API_ROOT
 
 configure_runner() {
-  local args token
+  local args
 
   args=()
   if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
@@ -134,8 +131,7 @@ configure_runner() {
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     [[ -n "$RUNNER_TOKEN" ]] && fail "RUNNER_TOKEN is mutually exclusive with ACCESS_TOKEN"
     echo "Obtaining the token of the runner"
-    token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
-    RUNNER_TOKEN=$(jq -re .token <<< "$token") || fail "[.token] not found in token.sh output"
+    RUNNER_TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
   fi
 
   # shellcheck disable=SC2153

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,25 +13,7 @@ export -n RUNNER_TOKEN
 export -n APP_ID
 export -n APP_PRIVATE_KEY
 
-log() {
-    local level
-    level="$1"; shift
-    echo -e "$level: $*" 1>&2
-}
-
-fail() {
-    log FAIL "$*"
-    exit 1
-}
-
-trap_with_arg() {
-    local func
-    func="$1"; shift
-    for sig; do
-        # shellcheck disable=SC2064
-        trap "$func $sig" "$sig"
-    done
-}
+source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
 deregister_runner() {
   local nl token

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ trap_with_arg() {
 }
 
 deregister_runner() {
-  local nl new_access_token token
+  local nl token
 
   echo "Caught $1 - Deregistering runner"
   if [[ -n "${ACCESS_TOKEN}" ]]; then
@@ -43,16 +43,15 @@ deregister_runner() {
       echo "Refreshing access token for deregistration"
       nl='
 '
-      new_access_token=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
-          APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
-      if [[ -z "${new_access_token}" || "${new_access_token}" == "null" ]]; then
+      ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
+          APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
+      if [[ -z "${ACCESS_TOKEN}" || "${ACCESS_TOKEN}" == "null" ]]; then
         fail "Failed to refresh access token for deregistration"
       fi
-      ACCESS_TOKEN="${new_access_token}"
       echo "Access token refreshed successfully"
     fi
-    token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
-    RUNNER_TOKEN=$(jq -r .token <<< "$token")
+    token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
+    RUNNER_TOKEN=$(jq -re .token <<< "$token") || fail "[.token] not found in token.sh output"
   fi
 
   ./config.sh remove --token "${RUNNER_TOKEN}"
@@ -145,15 +144,15 @@ configure_runner() {
     nl='
 '
     ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
-        APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
+        APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
   elif [[ -n "${APP_ID}" || -n "${APP_PRIVATE_KEY}" || -n "${APP_LOGIN}" ]]; then
     fail "either all or none of APP_ID, APP_PRIVATE_KEY and APP_LOGIN must be specified"
   fi
 
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     echo "Obtaining the token of the runner"
-    token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
-    RUNNER_TOKEN=$(jq -r .token <<< "$token")
+    token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
+    RUNNER_TOKEN=$(jq -re .token <<< "$token") || fail "[.token] not found in token.sh output"
   fi
 
   # shellcheck disable=SC2153

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ deregister_runner() {
     # If using GitHub App authentication, refresh the access token before deregistration
     if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
       echo "Refreshing access token for deregistration"
-      ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/$'\n'}" \
+      ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY}" \
           APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
       echo "Access token refreshed successfully"
     fi
@@ -68,6 +68,7 @@ fi
 : "${START_DOCKER_SERVICE:=false}"
 : "${UNSET_CONFIG_VARS:=false}"
 : "${CONFIGURED_ACTIONS_RUNNER_FILES_DIR:=''}"
+APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/$'\n'}"
 # as to why $RUNNER_LABELS is used, see https://github.com/myoung34/docker-github-actions-runner/commit/ac80687f5e2a3a34b11a80daa6089281f186c2d5
 LABELS=${RUNNER_LABELS:-${LABELS:-default}}
 
@@ -121,7 +122,7 @@ configure_runner() {
       fail "ACCESS_TOKEN or RUNNER_TOKEN provided but are mutually exclusive with {APP_ID, APP_PRIVATE_KEY, APP_LOGIN}"
     fi
     echo "Obtaining access token for app_id ${APP_ID} and login ${APP_LOGIN}"
-    ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/$'\n'}" \
+    ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY}" \
         APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
   elif [[ -n "${APP_ID}" || -n "${APP_PRIVATE_KEY}" || -n "${APP_LOGIN}" ]]; then
     fail "either all or none of {APP_ID, APP_PRIVATE_KEY, APP_LOGIN} must be specified"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,21 @@ export -n RUNNER_TOKEN
 export -n APP_ID
 export -n APP_PRIVATE_KEY
 
+err() {
+    local level
+    level="$1"; shift
+    echo -e "$level: $*" 1>&2
+}
+
+fail() {
+    err FAIL "$*"
+    exit 1
+}
+
 trap_with_arg() {
-    func="$1" ; shift
-    for sig ; do
+    local func
+    func="$1"; shift
+    for sig; do
         # shellcheck disable=SC2064
         trap "$func $sig" "$sig"
     done
@@ -31,8 +43,7 @@ deregister_runner() {
       NEW_ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
           APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
       if [[ -z "${NEW_ACCESS_TOKEN}" || "${NEW_ACCESS_TOKEN}" == "null" ]]; then
-        echo "ERROR: Failed to refresh access token for deregistration"
-        exit 1
+        fail "Failed to refresh access token for deregistration"
       fi
       ACCESS_TOKEN="${NEW_ACCESS_TOKEN}"
       echo "Access token refreshed successfully"
@@ -51,7 +62,7 @@ _DISABLE_AUTOMATIC_DEREGISTRATION=${DISABLE_AUTOMATIC_DEREGISTRATION:-false}
 
 _RANDOM_RUNNER_SUFFIX=${RANDOM_RUNNER_SUFFIX:="true"}
 
-_RUNNER_NAME=${RUNNER_NAME:-${RUNNER_NAME_PREFIX:-github-runner}-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')}
+_RUNNER_NAME=${RUNNER_NAME:-${RUNNER_NAME_PREFIX:-github-runner}-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13; echo '')}
 if [[ ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
   # In some cases this file does not exist
   if [[ -s "/etc/hostname" ]]; then
@@ -61,10 +72,10 @@ if [[ ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
       _RUNNER_NAME=${RUNNER_NAME:-${_RUNNER_NAME_PREFIX:+${_RUNNER_NAME_PREFIX}-}$(cat /etc/hostname)}
       echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX}. /etc/hostname exists and has content. Setting runner name to ${_RUNNER_NAME}"
     else
-      echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} ./etc/hostname exists but is empty. Not using /etc/hostname."
+      echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} ./etc/hostname exists but is empty. Not using /etc/hostname"
     fi
   else
-    echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} but /etc/hostname does not exist. Not using /etc/hostname."
+    echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} but /etc/hostname does not exist. Not using /etc/hostname"
   fi
 fi
 
@@ -91,7 +102,7 @@ RUNNER_SCOPE="${RUNNER_SCOPE,,}"  # to lowercase
 
 case "${RUNNER_SCOPE}" in
   org*)
-    [[ -z ${ORG_NAME} ]] && ( echo "ORG_NAME required for org runners"; exit 1 )
+    [[ -z ${ORG_NAME} ]] && fail "ORG_NAME required for org runners"
     _SHORT_URL="https://${_GITHUB_HOST}/${ORG_NAME}"
     RUNNER_SCOPE="org"
     if [[ -n "${APP_ID}" && -z "${APP_LOGIN}" ]]; then
@@ -100,13 +111,13 @@ case "${RUNNER_SCOPE}" in
     ;;
 
   ent*)
-    [[ -z ${ENTERPRISE_NAME} ]] && ( echo "ENTERPRISE_NAME required for enterprise runners"; exit 1 )
+    [[ -z ${ENTERPRISE_NAME} ]] && fail "ENTERPRISE_NAME required for enterprise runners"
     _SHORT_URL="https://${_GITHUB_HOST}/enterprises/${ENTERPRISE_NAME}"
     RUNNER_SCOPE="enterprise"
     ;;
 
   *)
-    [[ -z ${REPO_URL} ]] && ( echo "REPO_URL required for repo runners"; exit 1 )
+    [[ -z ${REPO_URL} ]] && fail "REPO_URL required for repo runners"
     _SHORT_URL=${REPO_URL}
     RUNNER_SCOPE="repo"
     if [[ -n "${APP_ID}" && -z "${APP_LOGIN}" ]]; then
@@ -122,8 +133,7 @@ configure_runner() {
   ARGS=()
   if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
     if [[ -n "${ACCESS_TOKEN}" || -n "${RUNNER_TOKEN}" ]]; then
-      echo "ERROR: ACCESS_TOKEN or RUNNER_TOKEN provided but are mutually exclusive with APP_ID, APP_PRIVATE_KEY and APP_LOGIN." >&2
-      exit 1
+      fail "ERROR: ACCESS_TOKEN or RUNNER_TOKEN provided but are mutually exclusive with {APP_ID, APP_PRIVATE_KEY, APP_LOGIN}"
     fi
     echo "Obtaining access token for app_id ${APP_ID} and login ${APP_LOGIN}"
     nl="
@@ -131,8 +141,7 @@ configure_runner() {
     ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
         APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
   elif [[ -n "${APP_ID}" || -n "${APP_PRIVATE_KEY}" || -n "${APP_LOGIN}" ]]; then
-    echo "ERROR: All of APP_ID, APP_PRIVATE_KEY and APP_LOGIN must be specified." >&2
-    exit 1
+    fail "ERROR: either all or none of APP_ID, APP_PRIVATE_KEY and APP_LOGIN must be specified"
   fi
 
   if [[ -n "${ACCESS_TOKEN}" ]]; then
@@ -230,8 +239,7 @@ fi
 if [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
   echo "Reusage is enabled. Storing data to ${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
   if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
-    echo "DISABLE_AUTOMATIC_DEREGISTRATION should be set to true to avoid issues with re-using a deregistered runner."
-    exit 1
+    fail "DISABLE_AUTOMATIC_DEREGISTRATION should be set to true to avoid issues with re-using a deregistered runner"
   fi
   # Quoting (even with double-quotes) the regexp brokes the copying
   cp -p -r "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
@@ -289,8 +297,7 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
       "$@"
     fi
   else
-    echo "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root, but UID '$(id -u)'"
-    exit 1
+    fail "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root, but UID [$(id -u)]"
   fi
 else
   if [[ $(id -u) -eq 0 ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/dumb-init /bin/bash
 # shellcheck shell=bash
+
 set -o pipefail
 
 export RUNNER_ALLOW_RUNASROOT=1
@@ -12,14 +13,14 @@ export -n RUNNER_TOKEN
 export -n APP_ID
 export -n APP_PRIVATE_KEY
 
-err() {
+log() {
     local level
     level="$1"; shift
     echo -e "$level: $*" 1>&2
 }
 
 fail() {
-    err FAIL "$*"
+    log FAIL "$*"
     exit 1
 }
 
@@ -33,24 +34,27 @@ trap_with_arg() {
 }
 
 deregister_runner() {
+  local nl new_access_token token
+
   echo "Caught $1 - Deregistering runner"
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     # If using GitHub App authentication, refresh the access token before deregistration
     if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
       echo "Refreshing access token for deregistration"
-      nl="
-"
-      NEW_ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
+      nl='
+'
+      new_access_token=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
           APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
-      if [[ -z "${NEW_ACCESS_TOKEN}" || "${NEW_ACCESS_TOKEN}" == "null" ]]; then
+      if [[ -z "${new_access_token}" || "${new_access_token}" == "null" ]]; then
         fail "Failed to refresh access token for deregistration"
       fi
-      ACCESS_TOKEN="${NEW_ACCESS_TOKEN}"
+      ACCESS_TOKEN="${new_access_token}"
       echo "Access token refreshed successfully"
     fi
-    _TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
-    RUNNER_TOKEN=$(echo "${_TOKEN}" | jq -r .token)
+    token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
+    RUNNER_TOKEN=$(jq -r .token <<< "$token")
   fi
+
   ./config.sh remove --token "${RUNNER_TOKEN}"
   [[ -f "/actions-runner/.runner" ]] && rm -f /actions-runner/.runner
   exit
@@ -86,7 +90,7 @@ _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 _RUN_AS_ROOT=${RUN_AS_ROOT:="true"}
 _START_DOCKER_SERVICE=${START_DOCKER_SERVICE:="false"}
 _UNSET_CONFIG_VARS=${UNSET_CONFIG_VARS:="false"}
-_CONFIGURED_ACTIONS_RUNNER_FILES_DIR=${CONFIGURED_ACTIONS_RUNNER_FILES_DIR:-""}
+_CONFIGURED_ACTIONS_RUNNER_FILES_DIR=${CONFIGURED_ACTIONS_RUNNER_FILES_DIR:-''}
 
 # ensure backwards compatibility
 if [[ -z ${RUNNER_SCOPE} ]]; then
@@ -130,40 +134,42 @@ esac
 export RUNNER_SCOPE
 
 configure_runner() {
-  ARGS=()
+  local args nl token
+
+  args=()
   if [[ -n "${APP_ID}" && -n "${APP_PRIVATE_KEY}" && -n "${APP_LOGIN}" ]]; then
     if [[ -n "${ACCESS_TOKEN}" || -n "${RUNNER_TOKEN}" ]]; then
-      fail "ERROR: ACCESS_TOKEN or RUNNER_TOKEN provided but are mutually exclusive with {APP_ID, APP_PRIVATE_KEY, APP_LOGIN}"
+      fail "ACCESS_TOKEN or RUNNER_TOKEN provided but are mutually exclusive with {APP_ID, APP_PRIVATE_KEY, APP_LOGIN}"
     fi
     echo "Obtaining access token for app_id ${APP_ID} and login ${APP_LOGIN}"
-    nl="
-"
+    nl='
+'
     ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/${nl}}" \
         APP_LOGIN="${APP_LOGIN}" bash /app_token.sh)
   elif [[ -n "${APP_ID}" || -n "${APP_PRIVATE_KEY}" || -n "${APP_LOGIN}" ]]; then
-    fail "ERROR: either all or none of APP_ID, APP_PRIVATE_KEY and APP_LOGIN must be specified"
+    fail "either all or none of APP_ID, APP_PRIVATE_KEY and APP_LOGIN must be specified"
   fi
 
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     echo "Obtaining the token of the runner"
-    _TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
-    RUNNER_TOKEN=$(echo "${_TOKEN}" | jq -r .token)
+    token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh)
+    RUNNER_TOKEN=$(jq -r .token <<< "$token")
   fi
 
   # shellcheck disable=SC2153
   if [[ -n "${EPHEMERAL}" ]]; then
     echo "Ephemeral option is enabled"
-    ARGS+=("--ephemeral")
+    args+=("--ephemeral")
   fi
 
   if [[ -n "${DISABLE_AUTO_UPDATE}" ]]; then
     echo "Disable auto update option is enabled"
-    ARGS+=("--disableupdate")
+    args+=("--disableupdate")
   fi
 
   if [[ -n "${NO_DEFAULT_LABELS}" ]]; then
     echo "Disable adding the default self-hosted, platform, and architecture labels"
-    ARGS+=("--no-default-labels")
+    args+=("--no-default-labels")
   fi
 
   echo "Configuring"
@@ -176,10 +182,9 @@ configure_runner() {
       --runnergroup "${_RUNNER_GROUP}" \
       --unattended \
       --replace \
-      "${ARGS[@]}"
+      "${args[@]}"
 
   [[ ! -d "${_RUNNER_WORKDIR}" ]] && mkdir -p "${_RUNNER_WORKDIR}"
-
 }
 
 unset_config_vars() {
@@ -242,7 +247,7 @@ if [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]]; then
     fail "DISABLE_AUTOMATIC_DEREGISTRATION should be set to true to avoid issues with re-using a deregistered runner"
   fi
   # Quoting (even with double-quotes) the regexp brokes the copying
-  cp -p -r "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
+  cp -pr "/actions-runner/_diag" "/actions-runner/svc.sh" /actions-runner/.[^.]* "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
 fi
 
 
@@ -256,7 +261,7 @@ fi
 # Start docker service if needed (e.g. for docker-in-docker)
 if [[ ${_START_DOCKER_SERVICE} == "true" ]]; then
   echo "Starting docker service"
-  _PREFIX=""
+  _PREFIX=''
   [[ ${_RUN_AS_ROOT} != "true" ]] && _PREFIX="sudo"
 
   if [[ ${_DEBUG_ONLY} == "true" ]]; then
@@ -275,7 +280,7 @@ fi
 
 
 if [[ ${_DEBUG_ONLY} == "true" || ${_DEBUG_OUTPUT} == "true" ]]; then
-  echo ""
+  echo ''
   echo "Disable automatic registration: ${_DISABLE_AUTOMATIC_DEREGISTRATION}"
   echo "Random runner suffix: ${_RANDOM_RUNNER_SUFFIX}"
   echo "Runner name: ${_RUNNER_NAME}"
@@ -297,7 +302,7 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
       "$@"
     fi
   else
-    fail "ERROR: RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root, but UID [$(id -u)]"
+    fail "RUN_AS_ROOT env var is set to true but the user has been overridden and is not running as root, but UID [$(id -u)]"
   fi
 else
   if [[ $(id -u) -eq 0 ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ export GH_API_VER=v3
 
 export RUNNER_ALLOW_RUNASROOT=1
 export PATH=${PATH}:/actions-runner
+export NO_COLOR=true  # make sure jq does not produce color output
 
 # Un-export these, so that they must be passed explicitly to the environment of
 # any command that needs them.  This may help prevent leaks.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,7 @@ deregister_runner() {
 
 : "${DEBUG_ONLY:=false}"
 : "${DEBUG_OUTPUT:=false}"
+[[ "$DEBUG_ONLY" == true || "$DEBUG_OUTPUT" == true ]] && DEBUG=true
 : "${DISABLE_AUTOMATIC_DEREGISTRATION:=false}"
 : "${RANDOM_RUNNER_SUFFIX:=true}"
 
@@ -233,7 +234,7 @@ fi
 
 # Container's command (CMD) execution as runner user
 
-if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
+if [[ "$DEBUG" == true ]]; then
   echo ''
   echo "Disable automatic registration: ${DISABLE_AUTOMATIC_DEREGISTRATION}"
   echo "Random runner suffix: ${RANDOM_RUNNER_SUFFIX}"
@@ -256,7 +257,7 @@ fi
 
 if [[ ${RUN_AS_ROOT} == "true" ]]; then
   if [[ $(id -u) -eq 0 ]]; then
-    if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
+    if [[ "$DEBUG" == true ]]; then
       # shellcheck disable=SC2145
       echo "Running $@"
     fi
@@ -272,7 +273,7 @@ else
     chown -R runner "${RUNNER_WORKDIR}" /actions-runner
     # The toolcache is not recursively chowned to avoid recursing over prepulated tooling in derived docker images
     chown runner /opt/hostedtoolcache/
-    if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
+    if [[ "$DEBUG" == true ]]; then
       # shellcheck disable=SC2145
       echo "Running /usr/sbin/gosu runner $@"
     fi
@@ -280,7 +281,7 @@ else
       /usr/sbin/gosu runner "$@"
     fi
   else
-    if [[ ${DEBUG_ONLY} == "true" || ${DEBUG_OUTPUT} == "true" ]]; then
+    if [[ "$DEBUG" == true ]]; then
       # shellcheck disable=SC2145
       echo "Running $@"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@
 
 set -o pipefail
 
+API_VERSION=v3
+
 export RUNNER_ALLOW_RUNASROOT=1
 export PATH=${PATH}:/actions-runner
 
@@ -58,6 +60,14 @@ fi
 : "${RUNNER_WORKDIR:=/_work/${RUNNER_NAME}}"
 : "${RUNNER_GROUP:=Default}"
 : "${GITHUB_HOST:=github.com}"
+
+# If URL is not github.com then use the enterprise api endpoint
+if [[ ${GITHUB_HOST} == github.com ]]; then
+  GH_API_ROOT="https://api.${GITHUB_HOST}"
+else
+  GH_API_ROOT="https://${GITHUB_HOST}/api/$API_VERSION"
+fi
+
 : "${RUN_AS_ROOT:=true}"
 : "${START_DOCKER_SERVICE:=false}"
 : "${UNSET_CONFIG_VARS:=false}"
@@ -104,7 +114,7 @@ case "${RUNNER_SCOPE}" in
     ;;
 esac
 
-export RUNNER_SCOPE GITHUB_HOST
+export RUNNER_SCOPE GH_API_ROOT API_VERSION
 
 configure_runner() {
   local args token

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 
 set -o pipefail
 
-API_VERSION=v3
+export GH_API_VER=v3
 
 export RUNNER_ALLOW_RUNASROOT=1
 export PATH=${PATH}:/actions-runner
@@ -14,6 +14,7 @@ export -n ACCESS_TOKEN
 export -n RUNNER_TOKEN
 export -n APP_ID
 export -n APP_PRIVATE_KEY
+export -n APP_LOGIN
 
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
@@ -27,9 +28,6 @@ deregister_runner() {
       echo "Refreshing access token for deregistration"
       ACCESS_TOKEN=$(APP_ID="${APP_ID}" APP_PRIVATE_KEY="${APP_PRIVATE_KEY//\\n/$'\n'}" \
           APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
-      if [[ -z "${ACCESS_TOKEN}" || "${ACCESS_TOKEN}" == "null" ]]; then
-        fail "Failed to refresh access token for deregistration"
-      fi
       echo "Access token refreshed successfully"
     fi
     token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
@@ -55,7 +53,7 @@ if [[ -z "$RUNNER_NAME" && ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
     echo "RANDOM_RUNNER_SUFFIX is ${RANDOM_RUNNER_SUFFIX} but /etc/hostname is not a non-empty file. Not using it"
   fi
 fi
-: "${RUNNER_NAME:=${RUNNER_NAME_PREFIX:-github-runner}-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')}"
+: "${RUNNER_NAME:=${RUNNER_NAME_PREFIX:-github-runner}-$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13; echo '')}"
 
 : "${RUNNER_WORKDIR:=/_work/${RUNNER_NAME}}"
 : "${RUNNER_GROUP:=Default}"
@@ -65,7 +63,7 @@ fi
 if [[ ${GITHUB_HOST} == github.com ]]; then
   GH_API_ROOT="https://api.${GITHUB_HOST}"
 else
-  GH_API_ROOT="https://${GITHUB_HOST}/api/$API_VERSION"
+  GH_API_ROOT="https://${GITHUB_HOST}/api/$GH_API_VER"
 fi
 
 : "${RUN_AS_ROOT:=true}"
@@ -114,7 +112,7 @@ case "${RUNNER_SCOPE}" in
     ;;
 esac
 
-export RUNNER_SCOPE GH_API_ROOT API_VERSION
+export RUNNER_SCOPE GH_API_ROOT
 
 configure_runner() {
   local args token
@@ -129,9 +127,12 @@ configure_runner() {
         APP_LOGIN="${APP_LOGIN}" bash /app_token.sh) || fail "app_token.sh failed with $?"
   elif [[ -n "${APP_ID}" || -n "${APP_PRIVATE_KEY}" || -n "${APP_LOGIN}" ]]; then
     fail "either all or none of {APP_ID, APP_PRIVATE_KEY, APP_LOGIN} must be specified"
+  elif [[ -z "$ACCESS_TOKEN" && -z "$RUNNER_TOKEN" ]]; then
+    fail "either {ACCESS_TOKEN or RUNNER_TOKEN} or {APP_ID and APP_PRIVATE_KEY} need to be provided"
   fi
 
   if [[ -n "${ACCESS_TOKEN}" ]]; then
+    [[ -n "$RUNNER_TOKEN" ]] && fail "RUNNER_TOKEN is mutually exclusive with ACCESS_TOKEN"
     echo "Obtaining the token of the runner"
     token=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
     RUNNER_TOKEN=$(jq -re .token <<< "$token") || fail "[.token] not found in token.sh output"
@@ -154,6 +155,7 @@ configure_runner() {
   fi
 
   echo "Configuring"
+  [[ ! -d "${RUNNER_WORKDIR}" ]] && mkdir -p "${RUNNER_WORKDIR}"
   ./config.sh \
       --url "${_SHORT_URL}" \
       --token "${RUNNER_TOKEN}" \
@@ -164,27 +166,21 @@ configure_runner() {
       --unattended \
       --replace \
       "${args[@]}"
-
-  [[ ! -d "${RUNNER_WORKDIR}" ]] && mkdir -p "${RUNNER_WORKDIR}"
 }
 
 unset_config_vars() {
-  echo "Unsetting configuration environment variables"
+  echo "Unsetting some configuration environment variables"
   unset RUNNER_NAME
   unset RUNNER_NAME_PREFIX
   unset RANDOM_RUNNER_SUFFIX
-  unset ACCESS_TOKEN
-  unset APP_ID
-  unset APP_PRIVATE_KEY
-  unset APP_LOGIN
   unset RUNNER_SCOPE
   unset ORG_NAME
   unset ENTERPRISE_NAME
   unset LABELS
   unset REPO_URL
-  unset RUNNER_TOKEN
   unset RUNNER_GROUP
   unset GITHUB_HOST
+  unset GH_API_ROOT
   unset DISABLE_AUTOMATIC_DEREGISTRATION
   unset EPHEMERAL
   unset DISABLE_AUTO_UPDATE
@@ -230,13 +226,12 @@ fi
 # Start docker service if needed (e.g. for docker-in-docker)
 if [[ ${START_DOCKER_SERVICE} == "true" ]]; then
   echo "Starting docker service"
-  _PREFIX=''
-  [[ ${RUN_AS_ROOT} != "true" ]] && _PREFIX="sudo"
+  [[ ${RUN_AS_ROOT} != "true" ]] && _SUDO=sudo || _SUDO=''
 
   if [[ ${DEBUG_ONLY} == "true" ]]; then
-    echo ${_PREFIX} service docker start
+    echo ${_SUDO} service docker start
   else
-    ${_PREFIX} service docker start
+    ${_SUDO} service docker start || fail "[docker start] failed w/ $?"
   fi
 fi
 
@@ -257,7 +252,9 @@ fi
 
 if [[ ${DISABLE_AUTOMATIC_DEREGISTRATION} == "false" && ${DEBUG_ONLY} == "false" ]]; then
   trap_with_sig  deregister_runner SIGINT SIGQUIT SIGTERM INT TERM QUIT
-elif [[ ${UNSET_CONFIG_VARS} == "true" ]]; then
+fi
+
+if [[ ${UNSET_CONFIG_VARS} == "true" ]]; then
   unset_config_vars
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -135,7 +135,6 @@ configure_runner() {
     RUNNER_TOKEN=$(ACCESS_TOKEN="${ACCESS_TOKEN}" bash /token.sh) || fail "token.sh failed with $?"
   fi
 
-  # shellcheck disable=SC2153
   if [[ -n "${EPHEMERAL}" ]]; then
     echo "Ephemeral option is enabled"
     args+=("--ephemeral")

--- a/install_actions.sh
+++ b/install_actions.sh
@@ -7,7 +7,7 @@ if [[ $TARGETPLATFORM == "linux/arm64" ]]; then
   export TARGET_ARCH="arm64"
 fi
 
-curl -L "https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-${TARGET_ARCH}-${GH_RUNNER_VERSION}.tar.gz" > actions.tar.gz
+curl -Lf "https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-${TARGET_ARCH}-${GH_RUNNER_VERSION}.tar.gz" > actions.tar.gz
 tar -zxf actions.tar.gz
 rm -f actions.tar.gz
 ./bin/installdependencies.sh

--- a/install_actions.sh
+++ b/install_actions.sh
@@ -6,6 +6,7 @@ export TARGET_ARCH="x64"
 if [[ $TARGETPLATFORM == "linux/arm64" ]]; then
   export TARGET_ARCH="arm64"
 fi
+
 curl -L "https://github.com/actions/runner/releases/download/v${GH_RUNNER_VERSION}/actions-runner-linux-${TARGET_ARCH}-${GH_RUNNER_VERSION}.tar.gz" > actions.tar.gz
 tar -zxf actions.tar.gz
 rm -f actions.tar.gz

--- a/token.sh
+++ b/token.sh
@@ -2,13 +2,13 @@
 
 set -o pipefail
 
-_GITHUB_HOST=${GITHUB_HOST:="github.com"}
+: "${GITHUB_HOST:=github.com}"
 
 # If URL is not github.com then use the enterprise api endpoint
 if [[ ${GITHUB_HOST} == "github.com" ]]; then
-  URI="https://api.${_GITHUB_HOST}"
+  URI="https://api.${GITHUB_HOST}"
 else
-  URI="https://${_GITHUB_HOST}/api/v3"
+  URI="https://${GITHUB_HOST}/api/v3"
 fi
 
 API_VERSION=v3
@@ -26,7 +26,7 @@ case ${RUNNER_SCOPE} in
     ;;
 
   *)
-    _PROTO="https://"
+    _PROTO='https://'
     # shellcheck disable=SC2116
     _URL="$(echo "${REPO_URL/${_PROTO}/}")"
     _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"

--- a/token.sh
+++ b/token.sh
@@ -3,12 +3,13 @@
 set -o pipefail
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
-API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
+API_HEADER="Accept: application/vnd.github.${GH_API_VER}+json"
 AUTH_HEADER="Authorization: token ${ACCESS_TOKEN}"
 CONTENT_LENGTH_HEADER="Content-Length: 0"
 
 case ${RUNNER_SCOPE} in
   org)
+    # https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-registration-token-for-an-organization
     _FULL_URL="${GH_API_ROOT}/orgs/${ORG_NAME}/actions/runners/registration-token"
     ;;
   enterprise)
@@ -21,6 +22,7 @@ case ${RUNNER_SCOPE} in
     _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
     _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
     _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+    # https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository
     _FULL_URL="${GH_API_ROOT}/repos/${_ACCOUNT}/${_REPO}/actions/runners/registration-token"
     ;;
   *) fail "unexpected runner scope [$RUNNER_SCOPE] -- report this issue to project upstream" ;;

--- a/token.sh
+++ b/token.sh
@@ -25,10 +25,8 @@ case ${RUNNER_SCOPE} in
   *) fail "unexpected runner scope [$RUNNER_SCOPE] -- report this issue to project upstream" ;;
 esac
 
-RUNNER_TOKEN="$(curl -XPOST -fsSL \
+curl -XPOST -fsSL \
   -H "${CONTENT_LENGTH_HEADER}" \
   -H "${AUTH_HEADER}" \
   -H "${API_HEADER}" \
-  "${_FULL_URL}" | jq -re .token)" || fail "$_FULL_URL fetch & [.token] extraction failed with $?"
-
-printf '{"token": "%s", "full_url": "%s"}' "$RUNNER_TOKEN" "$_FULL_URL"
+  "${_FULL_URL}" | jq -re .token || fail "$_FULL_URL fetch & [.token] extraction failed with $?"

--- a/token.sh
+++ b/token.sh
@@ -3,8 +3,6 @@
 set -o pipefail
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
-: "${GITHUB_HOST:=github.com}"
-
 # If URL is not github.com then use the enterprise api endpoint
 if [[ ${GITHUB_HOST} == "github.com" ]]; then
   URI="https://api.${GITHUB_HOST}"

--- a/token.sh
+++ b/token.sh
@@ -3,36 +3,27 @@
 set -o pipefail
 source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
-# If URL is not github.com then use the enterprise api endpoint
-if [[ ${GITHUB_HOST} == "github.com" ]]; then
-  URI="https://api.${GITHUB_HOST}"
-else
-  URI="https://${GITHUB_HOST}/api/v3"
-fi
-
-API_VERSION=v3
 API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
 AUTH_HEADER="Authorization: token ${ACCESS_TOKEN}"
 CONTENT_LENGTH_HEADER="Content-Length: 0"
 
 case ${RUNNER_SCOPE} in
-  org*)
-    _FULL_URL="${URI}/orgs/${ORG_NAME}/actions/runners/registration-token"
+  org)
+    _FULL_URL="${GH_API_ROOT}/orgs/${ORG_NAME}/actions/runners/registration-token"
     ;;
-
-  ent*)
-    _FULL_URL="${URI}/enterprises/${ENTERPRISE_NAME}/actions/runners/registration-token"
+  enterprise)
+    _FULL_URL="${GH_API_ROOT}/enterprises/${ENTERPRISE_NAME}/actions/runners/registration-token"
     ;;
-
-  *)
+  repo)
     _PROTO='https://'
     # shellcheck disable=SC2116
     _URL="$(echo "${REPO_URL/${_PROTO}/}")"
     _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
     _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
     _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
-    _FULL_URL="${URI}/repos/${_ACCOUNT}/${_REPO}/actions/runners/registration-token"
+    _FULL_URL="${GH_API_ROOT}/repos/${_ACCOUNT}/${_REPO}/actions/runners/registration-token"
     ;;
+  *) fail "unexpected runner scope [$RUNNER_SCOPE] -- report this issue to project upstream" ;;
 esac
 
 RUNNER_TOKEN="$(curl -XPOST -fsSL \

--- a/token.sh
+++ b/token.sh
@@ -16,12 +16,9 @@ case ${RUNNER_SCOPE} in
     _FULL_URL="${GH_API_ROOT}/enterprises/${ENTERPRISE_NAME}/actions/runners/registration-token"
     ;;
   repo)
-    _PROTO='https://'
-    # shellcheck disable=SC2116
-    _URL="$(echo "${REPO_URL/${_PROTO}/}")"
-    _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
-    _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
-    _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+    _URL="${REPO_URL#*://}"  # strip the protocol
+    _ACCOUNT="$(cut -d/ -f2 <<< "$_URL")"
+    _REPO="$(cut -d/ -f3 <<< "$_URL")"
     # https://docs.github.com/en/rest/actions/self-hosted-runners#create-a-registration-token-for-a-repository
     _FULL_URL="${GH_API_ROOT}/repos/${_ACCOUNT}/${_REPO}/actions/runners/registration-token"
     ;;

--- a/token.sh
+++ b/token.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -o pipefail
+source /common.sh || { echo -e "ERROR: failed to import /common.sh"; exit 1; }
 
 : "${GITHUB_HOST:=github.com}"
 
@@ -40,6 +41,6 @@ RUNNER_TOKEN="$(curl -XPOST -fsSL \
   -H "${CONTENT_LENGTH_HEADER}" \
   -H "${AUTH_HEADER}" \
   -H "${API_HEADER}" \
-  "${_FULL_URL}" | jq -re .token)" || exit $?
+  "${_FULL_URL}" | jq -re .token)" || fail "$_FULL_URL fetch & [.token] extraction failed with $?"
 
 printf '{"token": "%s", "full_url": "%s"}' "$RUNNER_TOKEN" "$_FULL_URL"

--- a/token.sh
+++ b/token.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+set -o pipefail
+
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 
 # If URL is not github.com then use the enterprise api endpoint
-if [[ ${GITHUB_HOST} = "github.com" ]]; then
+if [[ ${GITHUB_HOST} == "github.com" ]]; then
   URI="https://api.${_GITHUB_HOST}"
 else
   URI="https://${_GITHUB_HOST}/api/v3"
@@ -41,4 +43,4 @@ RUNNER_TOKEN="$(curl -XPOST -fsSL \
   "${_FULL_URL}" \
 | jq -r '.token')"
 
-echo "{\"token\": \"${RUNNER_TOKEN}\", \"full_url\": \"${_FULL_URL}\"}"
+printf '{"token": "%s", "full_url": "%s"}' "$RUNNER_TOKEN" "$_FULL_URL"

--- a/token.sh
+++ b/token.sh
@@ -40,7 +40,6 @@ RUNNER_TOKEN="$(curl -XPOST -fsSL \
   -H "${CONTENT_LENGTH_HEADER}" \
   -H "${AUTH_HEADER}" \
   -H "${API_HEADER}" \
-  "${_FULL_URL}" \
-| jq -r '.token')"
+  "${_FULL_URL}" | jq -re .token)" || exit $?
 
 printf '{"token": "%s", "full_url": "%s"}' "$RUNNER_TOKEN" "$_FULL_URL"


### PR DESCRIPTION
Mostly bash cleanup/simplification. Individual commit messages have needed/relevant info.

Few noteworthy _functional_ changes:

- note until now `deregister_runner()` was broken if `UNSET_CONFIG_VARS` was set, as `deregister_runner()` references some config vals that would've been unset beforehand.
  - I'd consider nuking `UNSET_CONFIG_VARS` altogether and remove that logic; or instead of `unset`ting, de-export all of them, like we're already doing for a select variables at the top of `entrypoint.sh`?
- curl & jq invocations get added -f/-e flags to fail fast;
- in app_token/request_access_token() we now assert the chosen app really does have required permissions set. this will help users when setting up the App & onboarding docker-github-runner itself.
