### PR TITLE
entrypoint: skip recursive chown over /actions-runner/{bin,externals}

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -290,7 +290,14 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
 else
   if [[ $(id -u) -eq 0 ]]; then
     [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && chown -R runner "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
-    chown -R runner "${_RUNNER_WORKDIR}" /actions-runner
+    # /actions-runner/{bin,externals} ship runner-owned from the image
+    # (~380 MB / 9k+ files). Recursing over them triggers overlay copy-up
+    # per file even when ownership already matches, which dominates startup
+    # under parallel runners. Only config.sh (run as root earlier) may have
+    # written new root-owned files at the top level — chown those plus
+    # /actions-runner itself and ${_RUNNER_WORKDIR}, but not the big dirs.
+    chown runner /actions-runner "${_RUNNER_WORKDIR}"
+    find /actions-runner -mindepth 1 -maxdepth 1 ! -name bin ! -name externals -exec chown -R runner {} + 2>/dev/null || true
     # The toolcache is not recursively chowned to avoid recursing over prepulated tooling in derived docker images
     chown runner /opt/hostedtoolcache/
     if [[ ${_DEBUG_ONLY} == "true" ]] || [[ ${_DEBUG_OUTPUT} == "true" ]] ; then


### PR DESCRIPTION
## What

Replace the recursive `chown -R runner "${_RUNNER_WORKDIR}" /actions-runner` on line 293 of `entrypoint.sh` with a targeted variant that:

- non-recursively chowns `/actions-runner` itself + `${_RUNNER_WORKDIR}`, and
- uses `find -maxdepth 1 ! -name bin ! -name externals -exec chown -R runner {} +` for every other top-level entry under `/actions-runner`.

`bin/` (~50 MB) and `externals/` (~330 MB) are skipped because the image already ships them `runner:runner`.

## Why

Verify on a pristine image:

```sh
docker run --rm --entrypoint sh myoung34/github-runner:ubuntu-noble \
    -c 'find /actions-runner -not -user runner'
# => prints nothing
```

Yet the current recursive chown walks 9 100+ files per container start. On overlayfs each `chown` syscall triggers copy-up even when ownership does not change, so the walk costs real disk I/O to flip exactly nothing. Under parallel starts the storage-driver contention dominates time-to-healthy.

The only genuinely root-owned files at chown time are the ones `config.sh` writes earlier in the same `entrypoint.sh` (`.runner`, `.credentials*`, `.env`, `.path`, `svc.sh`, and eventually `_diag/`). The `find`-based blacklist keeps chowning all of them (plus anything new `config.sh` might add in the future) while skipping the two known-heavy read-only dirs.

## Measured impact

Host: LXC on Proxmox (ZFS-backed), 12 runner containers started in parallel via `docker compose`.

| | before | after |
|---|---:|---:|
| all-12-containers time-to-healthy | ~5 min | ~25 s |
| per-container `docker compose up -d` return | 1 s nominal, but 11 peers racing for copy-up I/O | ~1 s, no contention |

Single-container ephemeral starts on fast storage also benefit proportionally to the size of `externals/` (~9 000 files).

## Scope

- **Changed**: only the one recursive chown line.
- **Unchanged**: `_CONFIGURED_ACTIONS_RUNNER_FILES_DIR` chown (line 292), toolcache flat-chown (line 295), the `RUN_AS_ROOT=true` and non-root branches, `_DEBUG_ONLY` / `_DEBUG_OUTPUT` handling.

## Prior art

Same spirit as #268 which narrowed the `/opt/hostedtoolcache` chown for the same reason (cache of already-correctly-owned files). This PR does the analogous narrowing for `/actions-runner`, which was not part of that change. Also relates to #239 and #267 (the `/opt/hostedtoolcache` half has been fixed; the `/actions-runner` half survives).

## Notes / open questions

Happy to split further if a smaller diff is preferred — e.g. keep only the `find`-blacklist behind an opt-in env var. Also happy to add a similar narrowing in `Dockerfile` (recursive `chown runner` after tarball extract) so derived images don't depend on the tarball's happening-to-be-runner-owned ownership.