### PR TITLE
fix: deregister runner on unexpected exit via EXIT trap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,17 @@ jobs:
             if [ $? -ne 0 ]; then
               exit 1
             fi
+            # test the EXIT trap on process crash
+            GOSS_VARS=goss_vars_${GH_RUNNER_IMAGE}.yaml GOSS_FILE=goss_trap_exit.yaml GOSS_SLEEP=1 dgoss run --entrypoint /usr/bin/sleep \
+            -e DEBUG_ONLY=false \
+            -e REPO_URL=https://github.com/fake/repo \
+            -e RUNNER_TOKEN=faketoken \
+            -e RUN_AS_ROOT=true \
+            -e DISABLE_AUTOMATIC_DEREGISTRATION=false \
+            ${GH_RUNNER_IMAGE} 300
+            if [ $? -ne 0 ]; then
+              exit 1
+            fi
   debian_tests:
     runs-on: ubuntu-latest
     strategy:
@@ -233,3 +244,14 @@ jobs:
             -e EPHEMERAL=true \
             -e DISABLE_AUTO_UPDATE=true \
             ${GH_RUNNER_IMAGE} 10
+            # test the EXIT trap on process crash
+            GOSS_VARS=goss_vars_${GH_RUNNER_IMAGE}.yaml GOSS_FILE=goss_trap_exit.yaml GOSS_SLEEP=1 dgoss run --entrypoint /usr/bin/sleep \
+            -e DEBUG_ONLY=false \
+            -e REPO_URL=https://github.com/fake/repo \
+            -e RUNNER_TOKEN=faketoken \
+            -e RUN_AS_ROOT=true \
+            -e DISABLE_AUTOMATIC_DEREGISTRATION=false \
+            ${GH_RUNNER_IMAGE} 300
+            if [ $? -ne 0 ]; then
+              exit 1
+            fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,8 +19,17 @@ trap_with_arg() {
     done
 }
 
+_DEREGISTERED=false
+
 deregister_runner() {
-  echo "Caught $1 - Deregistering runner"
+  if [[ "${_DEREGISTERED}" == "true" ]]; then
+    return
+  fi
+  _DEREGISTERED=true
+
+  local CAUGHT="${1:-EXIT}"
+  echo "Caught ${CAUGHT} - Deregistering runner"
+
   if [[ -n "${ACCESS_TOKEN}" ]]; then
     # If using GitHub App authentication, refresh the access token before deregistration
     if [[ -n "${APP_ID}" ]] && [[ -n "${APP_PRIVATE_KEY}" ]] && [[ -n "${APP_LOGIN}" ]]; then
@@ -40,7 +49,10 @@ deregister_runner() {
   fi
   ./config.sh remove --token "${RUNNER_TOKEN}"
   [[ -f "/actions-runner/.runner" ]] && rm -f /actions-runner/.runner
-  exit
+
+  if [[ "${CAUGHT}" != "EXIT" ]]; then
+    exit
+  fi
 }
 
 _DEBUG_ONLY=${DEBUG_ONLY:-false}
@@ -241,7 +253,7 @@ fi
 
 if [[ ${_DISABLE_AUTOMATIC_DEREGISTRATION} == "false" ]]; then
   if [[ ${_DEBUG_ONLY} == "false" ]]; then
-    trap_with_arg deregister_runner SIGINT SIGQUIT SIGTERM INT TERM QUIT
+    trap_with_arg deregister_runner SIGINT SIGQUIT SIGTERM INT TERM QUIT EXIT
   fi
 fi
 

--- a/goss_trap_exit.yaml
+++ b/goss_trap_exit.yaml
@@ -1,0 +1,10 @@
+command:
+  /entrypoint.sh /bin/bash -c "exit 1":
+    exit-status: 1
+    stdout:
+      - "Runner reusage is disabled"
+      - "Caught EXIT - Deregistering runner"
+    # DEBUG_ONLY=false is required so configure_runner runs and sets up the trap.
+    # The .NET runtime (config.sh) is slow under qemu arm64 emulation on x86_64,
+    # so a longer timeout is needed for this test to pass on arm64.
+    timeout: 120000


### PR DESCRIPTION
Revisits [#582](https://github.com/myoung34/docker-github-actions-runner/issues/581) with the repo owner feedback applied

Add EXIT to the trap list so deregister_runner fires on any exit, not just explicit signals

changes:

- local CAUGHT="${1:-EXIT}" to distinguish signal vs EXIT trap (as suggested in #582 review)
- _DEREGISTERED guard to prevent double config.sh remove when a signal trap triggers EXIT
-  [goss_trap_exit.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) test + CI steps with 300s container lifetime for QEMU arm64 compatibility