### PR TITLE
Ensure that the docker.sock file for a non-root user has execute permissions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -305,6 +305,15 @@ if [[ ${_RUN_AS_ROOT} == "true" ]]; then
     exit 1
   fi
 else
+  # Ensure the docker group GID matches the mounted docker socket
+  if [[ -e /var/run/docker.sock ]]; then
+    _DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock)
+    _CURRENT_DOCKER_GID=$(getent group docker | cut -d: -f3 2>/dev/null || echo "")
+    if [[ -n "${_DOCKER_SOCK_GID}" ]] && [[ "${_DOCKER_SOCK_GID}" != "${_CURRENT_DOCKER_GID}" ]]; then
+      echo "Adjusting docker group GID to match socket (${_DOCKER_SOCK_GID})"
+      groupmod -g "${_DOCKER_SOCK_GID}" docker 2>/dev/null || true
+    fi
+  fi
   if [[ $(id -u) -eq 0 ]]; then
     [[ -n "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}" ]] && chown -R runner "${_CONFIGURED_ACTIONS_RUNNER_FILES_DIR}"
     # /actions-runner/{bin,externals} ship runner-owned from the image


### PR DESCRIPTION
- Fixes #604 .
- Ensure that the docker.sock file for a non-root user has execute permissions.
- This avoids using something like `--group-add "$(stat --format='%g' /var/run/docker.sock)"`. To make a long story short, this is how I start a Docker container now.

```bash
docker run -d --restart unless-stopped \
  --name github-runner-test \
  -e ACCESS_TOKEN="github_pat_sometoken" \
  -e RUNNER_NAME="github-runner-test" \
  -e RUNNER_SCOPE="org" \
  -e ORG_NAME="some-org" \
  -e RUN_AS_ROOT="false" \
  -u "runner" \
  --group-add "$(stat --format='%g' /var/run/docker.sock)" \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v runner_workdir_test:/_work \
  myoung34/github-runner:2.334.0-ubuntu-noble
```

The current PR aims to avoid the `--group-add "$(stat --format='%g' /var/run/docker.sock)"` parameter. That is,

```bash
docker run -d --restart unless-stopped \
  --name github-runner-test \
  -e ACCESS_TOKEN="github_pat_sometoken" \
  -e RUNNER_NAME="github-runner-test" \
  -e RUNNER_SCOPE="org" \
  -e ORG_NAME="some-org" \
  -e RUN_AS_ROOT="false" \
  -u "runner" \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v runner_workdir_test:/_work \
  myoung34/github-runner:snapshot
```