### PR TITLE
docs: fix self-hosted runner docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Docker Github Actions Runner
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/myoung34/github-runner.svg)](https://hub.docker.com/r/myoung34/github-runner) [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
 
-This will run the [new self-hosted github actions runners](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/hosting-your-own-runners).
+This will run the [new self-hosted github actions runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners).
 
 ## Quick-Start (Examples and Usage) ##
 


### PR DESCRIPTION
## Summary
- Replace the legacy GitHub Help self-hosted runners link in the README with the current GitHub Docs page.
- Keeps the README wording unchanged and only updates the broken href.

## Validation
- Old URL final response: HTTP 404
- New URL: HTTP 200
- git diff --check
- Claude Code CLI review: PASS

Closes #601