### PR TITLE
feat: add ENABLE_RUNNER_WORKDIR_SUFFIX for per-runner workdirs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,19 @@ jobs:
             if [ $? -ne 0 ]; then
               exit 1
             fi
+            # test ENABLE_RUNNER_WORKDIR_SUFFIX suffixes and cleans up the per-runner workdir on exit
+            GOSS_VARS=goss_vars_${GH_RUNNER_IMAGE}.yaml GOSS_FILE=goss_workdir_suffix.yaml GOSS_SLEEP=1 dgoss run --entrypoint /usr/bin/sleep \
+            -e DEBUG_ONLY=false \
+            -e REPO_URL=https://github.com/fake/repo \
+            -e RUNNER_TOKEN=faketoken \
+            -e RUN_AS_ROOT=true \
+            -e DISABLE_AUTOMATIC_DEREGISTRATION=false \
+            -e ENABLE_RUNNER_WORKDIR_SUFFIX=true \
+            -e RUNNER_WORKDIR=/tmp/suffix \
+            ${GH_RUNNER_IMAGE} 300
+            if [ $? -ne 0 ]; then
+              exit 1
+            fi
   debian_tests:
     runs-on: ubuntu-latest
     strategy:
@@ -251,6 +264,19 @@ jobs:
             -e RUNNER_TOKEN=faketoken \
             -e RUN_AS_ROOT=true \
             -e DISABLE_AUTOMATIC_DEREGISTRATION=false \
+            ${GH_RUNNER_IMAGE} 300
+            if [ $? -ne 0 ]; then
+              exit 1
+            fi
+            # test ENABLE_RUNNER_WORKDIR_SUFFIX suffixes and cleans up the per-runner workdir on exit
+            GOSS_VARS=goss_vars_${GH_RUNNER_IMAGE}.yaml GOSS_FILE=goss_workdir_suffix.yaml GOSS_SLEEP=1 dgoss run --entrypoint /usr/bin/sleep \
+            -e DEBUG_ONLY=false \
+            -e REPO_URL=https://github.com/fake/repo \
+            -e RUNNER_TOKEN=faketoken \
+            -e RUN_AS_ROOT=true \
+            -e DISABLE_AUTOMATIC_DEREGISTRATION=false \
+            -e ENABLE_RUNNER_WORKDIR_SUFFIX=true \
+            -e RUNNER_WORKDIR=/tmp/suffix \
             ${GH_RUNNER_IMAGE} 300
             if [ $? -ne 0 ]; then
               exit 1

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ These containers are built via Github actions that [copy the dockerfile](https:/
 | `REPO_URL` | If using a non-organization runner this is the full repository url to register under such as 'https://github.com/myoung34/repo' |
 | `RUNNER_TOKEN` | If not using a PAT for `ACCESS_TOKEN` this will be the runner token provided by the Add Runner UI (a manual process). Note: This token is short lived and will change frequently. `ACCESS_TOKEN` is likely preferred. |
 | `RUNNER_WORKDIR` | The working directory for the runner. Runners on the same host should not share this directory. Default is '/_work'. This must match the source path for the bind-mounted volume at RUNNER_WORKDIR, in order for container actions to access files. |
+| `ENABLE_RUNNER_WORKDIR_SUFFIX` | Optional boolean. When `true`, appends the runner name to `RUNNER_WORKDIR`, giving each runner a unique sub-directory so that runners sharing a `RUNNER_WORKDIR` (e.g. a shared build cache mount) do not collide. The unique directory is cleaned up on container exit (when automatic deregistration is enabled) to keep the shared cache from growing unbounded. Defaults to `false`. |
 | `RUNNER_GROUP` | Name of the runner group to add this runner to (defaults to the default runner group) |
 | `GITHUB_HOST` | Optional URL of the Github Enterprise server e.g github.mycompany.com. Defaults to `github.com`. |
 | `GITHUB_API_HOST` | Optional API host to use for token generation. Useful when the API host differs from `GITHUB_HOST`, e.g. `api.mycompany.ghe.com` for GitHub Enterprise Cloud with data residency. |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,19 @@ trap_with_arg() {
 
 _DEREGISTERED=false
 
+cleanup_runner_workdir() {
+  # Only owns/cleans a unique per-runner path when the suffix feature is on;
+  # otherwise the workdir may be shared or externally managed and must be
+  # left untouched.
+  if [[ "${_ENABLE_RUNNER_WORKDIR_SUFFIX}" != "true" ]]; then
+    return
+  fi
+  if [[ -n "${_RUNNER_WORKDIR}" ]] && [[ -d "${_RUNNER_WORKDIR}" ]]; then
+    echo "Cleaning up runner workdir ${_RUNNER_WORKDIR}"
+    rm -rf "${_RUNNER_WORKDIR}" || echo "WARNING: Failed to clean up runner workdir ${_RUNNER_WORKDIR}"
+  fi
+}
+
 deregister_runner() {
   local CAUGHT="${1:-EXIT}"
   echo "Caught ${CAUGHT} - Deregistering runner"
@@ -49,6 +62,8 @@ deregister_runner() {
   fi
   ./config.sh remove --token "${RUNNER_TOKEN}"
   [[ -f "/actions-runner/.runner" ]] && rm -f /actions-runner/.runner
+
+  cleanup_runner_workdir
 
   if [[ "${CAUGHT}" != "EXIT" ]]; then
     exit 1
@@ -82,6 +97,13 @@ if [[ ${RANDOM_RUNNER_SUFFIX} != "true" ]]; then
 fi
 
 _RUNNER_WORKDIR=${RUNNER_WORKDIR:-/_work/${_RUNNER_NAME}}
+_ENABLE_RUNNER_WORKDIR_SUFFIX=${ENABLE_RUNNER_WORKDIR_SUFFIX:-false}
+if [[ ${_ENABLE_RUNNER_WORKDIR_SUFFIX} == "true" ]]; then
+  # Give each runner its own subdirectory under the (potentially shared)
+  # workdir so runners don't collide on a shared build cache. The unique
+  # path is cleaned up on container exit (see cleanup_runner_workdir).
+  _RUNNER_WORKDIR="${_RUNNER_WORKDIR}/${_RUNNER_NAME}"
+fi
 _LABELS=${RUNNER_LABELS:-${LABELS:-default}}
 _RUNNER_GROUP=${RUNNER_GROUP:-Default}
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
@@ -288,6 +310,7 @@ if [[ ${_DEBUG_ONLY} == "true" ]] || [[ ${_DEBUG_OUTPUT} == "true" ]] ; then
   echo "Random runner suffix: ${_RANDOM_RUNNER_SUFFIX}"
   echo "Runner name: ${_RUNNER_NAME}"
   echo "Runner workdir: ${_RUNNER_WORKDIR}"
+  echo "Runner workdir suffix: ${_ENABLE_RUNNER_WORKDIR_SUFFIX}"
   echo "Labels: ${_LABELS}"
   echo "Runner Group: ${_RUNNER_GROUP}"
   echo "Github Host: ${_GITHUB_HOST}"

--- a/goss_workdir_suffix.yaml
+++ b/goss_workdir_suffix.yaml
@@ -1,0 +1,12 @@
+command:
+  /entrypoint.sh /bin/bash -c "exit 1":
+    exit-status: 1
+    stdout:
+      - "Runner reusage is disabled"
+      - "Caught EXIT - Deregistering runner"
+      - "Cleaning up runner workdir /tmp/suffix/"
+    # DEBUG_ONLY=false is required so configure_runner runs, creates the
+    # suffixed workdir, and sets up the EXIT trap that triggers cleanup.
+    # The .NET runtime (config.sh) is slow under qemu arm64 emulation on x86_64,
+    # so a longer timeout is needed for this test to pass on arm64.
+    timeout: 120000


### PR DESCRIPTION
## What

Adds a new optional boolean environment variable **`ENABLE_RUNNER_WORKDIR_SUFFIX`** (default: `false`).

When `true`, the runner name (`_RUNNER_NAME`) is appended to `_RUNNER_WORKDIR`, giving each runner its own unique subdirectory. This lets runners that share a `RUNNER_WORKDIR` (e.g. a shared build-cache bind mount) avoid colliding on the same working directory.

When enabled, the unique per-runner directory is cleaned up at the end of the container lifecycle (via the existing deregistration `EXIT`/signal trap) so the shared cache doesn't grow unbounded.

## Why

Runners pointed at a shared `RUNNER_WORKDIR` currently collide on the same path. Suffixing with the runner name isolates them, and cleaning the directory on exit keeps a shared cache volume from accumulating stale work data over time.

## Behavior details

- Default (`false`): no change to existing behavior.
- Cleanup only runs when the suffix feature is enabled, so a shared or externally-managed `RUNNER_WORKDIR` is never removed.
- Cleanup fires through the deregistration trap, so it runs when automatic deregistration is enabled (the default). With `DISABLE_AUTOMATIC_DEREGISTRATION=true` (the runner-reusage path) the workdir is intentionally preserved, which is the correct behavior for reuse.

## Changes

- `entrypoint.sh`: new flag, suffix append, `cleanup_runner_workdir()` invoked from `deregister_runner()`, and a debug-output line.
- `README.md`: documented the new variable.
- `goss_workdir_suffix.yaml` + `.github/workflows/test.yml`: end-to-end goss test (wired into both matrix jobs) asserting the suffixed workdir is created and cleaned up on exit.

## Testing

- Debug run with the flag on → `Runner workdir: /tmp/a/huzzah`; default off → `Runner workdir: /tmp/a`.
- Unit-tested `cleanup_runner_workdir`: enabled removes the dir, disabled preserves it.
- Added goss coverage for the cleanup-on-exit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)